### PR TITLE
fix: save event time as naive UTC to eliminate conversion errors

### DIFF
--- a/apollo/frontend/views_admin.py
+++ b/apollo/frontend/views_admin.py
@@ -187,11 +187,11 @@ class EventAdminView(BaseAdminView):
         if form.participant_set.data:
             model.location_set = form.participant_set.data.location_set
 
-        # also, convert the time zone to UTC
+        # also, convert the time zone to naive UTC
         model.start = app_time_zone.localize(model.start).astimezone(
-            utc_time_zone)
+            utc_time_zone).replace(tzinfo=None)
         model.end = app_time_zone.localize(model.end).astimezone(
-            utc_time_zone)
+            utc_time_zone).replace(tzinfo=None)
 
 
 class UserAdminView(BaseAdminView):


### PR DESCRIPTION
prior this fix, saving then editing an event in the admin when the `TIMEZONE` app setting is not UTC would result in a discrepancy between the intended event start and end times and the actual data saved.