### PR TITLE
fix: remove invalid choice in deployment languages

### DIFF
--- a/apollo/frontend/views_admin.py
+++ b/apollo/frontend/views_admin.py
@@ -121,7 +121,7 @@ class DeploymentAdminView(BaseAdminView):
             _('Primary Language'), choices=LANGUAGE_CHOICES,
             validators=[validators.input_required()])
         form_class.other_locales = SelectMultipleField(
-            _('Other Languages'), choices=LANGUAGE_CHOICES)
+            _('Other Languages'), choices=LANGUAGE_CHOICES[1:])
 
         return form_class
 


### PR DESCRIPTION
Removes ```None``` as a choice for the ```other_language``` setting. See #242 