### PR TITLE
fix: add timestamp to form export

### DIFF
--- a/apollo/formsframework/views_forms.py
+++ b/apollo/formsframework/views_forms.py
@@ -410,11 +410,11 @@ def export_form(id):
     workbook.save(memory_file)
     memory_file.seek(0)
     current_timestamp = datetime.utcnow()
-    filename = slugify(f'{form.name}-{current_timestamp:%Y %m %d %H%M%S}.xls')
+    filename = slugify(f'{form.name}-{current_timestamp:%Y %m %d %H%M%S}')
 
     return send_file(
-        memory_file, attachment_filename=filename, as_attachment=True,
-        mimetype='application/vnd.ms-excel')
+        memory_file, attachment_filename=(filename + '.xls'),
+        as_attachment=True, mimetype='application/vnd.ms-excel')
 
 
 def import_form_schema():

--- a/apollo/formsframework/views_forms.py
+++ b/apollo/formsframework/views_forms.py
@@ -9,6 +9,7 @@ from flask import (
 from flask_babelex import lazy_gettext as _
 import json
 from flask_security import current_user
+from slugify import slugify
 
 from apollo import core, models
 from apollo.core import uploads
@@ -409,7 +410,7 @@ def export_form(id):
     workbook.save(memory_file)
     memory_file.seek(0)
     current_timestamp = datetime.utcnow()
-    filename = f'{form.name}-{current_timestamp:%Y %m %d %H%M%S}.xls'
+    filename = slugify(f'{form.name}-{current_timestamp:%Y %m %d %H%M%S}.xls')
 
     return send_file(
         memory_file, attachment_filename=filename, as_attachment=True,

--- a/apollo/formsframework/views_forms.py
+++ b/apollo/formsframework/views_forms.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from datetime import datetime
 from io import BytesIO
 
 from arpeggio import NoMatch
@@ -407,7 +408,8 @@ def export_form(id):
     workbook = utils.export_form(form)
     workbook.save(memory_file)
     memory_file.seek(0)
-    filename = '{}.xls'.format(form.name)
+    current_timestamp = datetime.utcnow()
+    filename = f'{form.name}-{current_timestamp:%Y%m%d-%H%M%S}.xls'
 
     return send_file(
         memory_file, attachment_filename=filename, as_attachment=True,

--- a/apollo/formsframework/views_forms.py
+++ b/apollo/formsframework/views_forms.py
@@ -409,7 +409,7 @@ def export_form(id):
     workbook.save(memory_file)
     memory_file.seek(0)
     current_timestamp = datetime.utcnow()
-    filename = f'{form.name}-{current_timestamp:%Y %m %d-%H%M%S}.xls'
+    filename = f'{form.name}-{current_timestamp:%Y %m %d %H%M%S}.xls'
 
     return send_file(
         memory_file, attachment_filename=filename, as_attachment=True,

--- a/apollo/formsframework/views_forms.py
+++ b/apollo/formsframework/views_forms.py
@@ -410,10 +410,10 @@ def export_form(id):
     workbook.save(memory_file)
     memory_file.seek(0)
     current_timestamp = datetime.utcnow()
-    filename = slugify(f'{form.name}-{current_timestamp:%Y %m %d %H%M%S}')
+    filename = slugify(f'{form.name}-{current_timestamp:%Y %m %d %H%M%S}') + '.xls'
 
     return send_file(
-        memory_file, attachment_filename=(filename + '.xls'),
+        memory_file, attachment_filename=filename,
         as_attachment=True, mimetype='application/vnd.ms-excel')
 
 

--- a/apollo/formsframework/views_forms.py
+++ b/apollo/formsframework/views_forms.py
@@ -409,7 +409,7 @@ def export_form(id):
     workbook.save(memory_file)
     memory_file.seek(0)
     current_timestamp = datetime.utcnow()
-    filename = f'{form.name}-{current_timestamp:%Y%m%d-%H%M%S}.xls'
+    filename = f'{form.name}-{current_timestamp:%Y %m %d-%H%M%S}.xls'
 
     return send_file(
         memory_file, attachment_filename=filename, as_attachment=True,


### PR DESCRIPTION
this commit addresses the issues of form exports being cached
by adding the UTC timestamp to the export filename.

see: nditech/apollo-issues#19