### PR TITLE
inverse QA logic

### DIFF
--- a/apollo/frontend/template_filters.py
+++ b/apollo/frontend/template_filters.py
@@ -107,12 +107,12 @@ def reverse_dict(d):
 def qa_status(submission, check):
     result, tags = get_inline_qa_status(submission, check)
     verified_fields = submission.verified_fields or set()
-    if result is True:
-        return QUALITY_STATUSES['OK']
-    elif result is False and tags.issubset(verified_fields):
+    if result is True and not tags.issubset(verified_fields):
+        return QUALITY_STATUSES['FLAGGED']
+    elif result is True and tags.issubset(verified_fields):
         return QUALITY_STATUSES['VERIFIED']
     elif result is False:
-        return QUALITY_STATUSES['FLAGGED']
+        return QUALITY_STATUSES['OK']
     else:
         return None
 

--- a/apollo/frontend/templates/frontend/quality_assurance_dashboard.html
+++ b/apollo/frontend/templates/frontend/quality_assurance_dashboard.html
@@ -66,7 +66,7 @@
           .set('Verified', json.Verified || 0)
           .set('OK', json.OK || 0)
           .set('Missing', json.Missing || 0);
-        var labels = ['Missing', 'Verified', 'OK', 'Flagged'];
+        var labels = ['Flagged', 'Verified', 'OK', 'Missing'];
         var labelsMap = d3.map()
           .set('Flagged', "{{ _('Flagged') }}")
           .set('Verified', "{{ _('Verified') }}")

--- a/apollo/submissions/models.py
+++ b/apollo/submissions/models.py
@@ -24,9 +24,9 @@ QUALITY_STATUSES = {
 }
 
 FLAG_CHOICES = (
-    ('0', _('OK')),
+    ('0', _('FLAGGED')),
     ('-1', _('MISSING')),
-    ('2', _('FLAGGED')),
+    ('2', _('OK')),
     ('4', _('VERIFIED')),
 )
 

--- a/apollo/submissions/qa/query_builder.py
+++ b/apollo/submissions/qa/query_builder.py
@@ -262,15 +262,15 @@ def generate_qa_queries(form):
 
             if used_tags:
                 case_query = case([
-                    (subquery == True, 'OK'),   # noqa
-                    (and_(subquery == False, Submission.verified_fields.has_all(tags)), 'Verified'),    # noqa
-                    (and_(subquery == False, ~Submission.verified_fields.has_all(tags)), 'Flagged'),    # noqa
+                    (subquery == True, ~Submission.verified_fields.has_all(tags)), 'Flagged'),  # noqa
+                    (and_(subquery == True, Submission.verified_fields.has_all(tags)), 'Verified'),   # noqa
+                    (and_(subquery == False, 'OK'), # noqa
                     (subquery == None, 'Missing')   # noqa
                 ]).label(check['name'])
             else:
                 case_query = case([
-                    (subquery == True, 'OK'),   # noqa
-                    (subquery == False, 'Flagged')   # noqa
+                    (subquery == True, 'Flagged'),   # noqa
+                    (subquery == False, 'OK')   # noqa
                 ]).label(check['name'])
 
             subqueries.append(case_query)
@@ -293,15 +293,15 @@ def get_logical_check_stats(query, form, condition):
 
     if question_codes:
         qa_case_query = case([
-            (qa_query == True, 'OK'),
-            (and_(qa_query == False, Submission.verified_fields.has_all(array(question_codes))), 'Verified'),   # noqa
-            (and_(qa_query == False, ~Submission.verified_fields.has_all(array(question_codes))), 'Flagged'),   # noqa
+            (qa_query == True, ~Submission.verified_fields.has_all(array(question_codes))), 'Flagged'), # noqa
+            (and_(qa_query == True, Submission.verified_fields.has_all(array(question_codes))), 'Verified'),    # noqa
+            (and_(qa_query == False, 'OK'), # noqa
             (qa_query == None, 'Missing')
         ])
     else:
         qa_case_query = case([
-            (qa_query == True, 'OK'),  # noqa
-            (qa_query == False, 'Flagged')
+            (qa_query == True, 'Flagged'),  # noqa
+            (qa_query == False, 'OK')
         ])
 
     return query.with_entities(

--- a/apollo/submissions/qa/query_builder.py
+++ b/apollo/submissions/qa/query_builder.py
@@ -262,9 +262,9 @@ def generate_qa_queries(form):
 
             if used_tags:
                 case_query = case([
-                    (subquery == True, ~Submission.verified_fields.has_all(tags)), 'Flagged'),  # noqa
+                    (and_(subquery == True, ~Submission.verified_fields.has_all(tags)), 'Flagged'),  # noqa
                     (and_(subquery == True, Submission.verified_fields.has_all(tags)), 'Verified'),   # noqa
-                    (and_(subquery == False, 'OK'), # noqa
+                    (subquery == False, 'OK'), # noqa
                     (subquery == None, 'Missing')   # noqa
                 ]).label(check['name'])
             else:
@@ -293,9 +293,9 @@ def get_logical_check_stats(query, form, condition):
 
     if question_codes:
         qa_case_query = case([
-            (qa_query == True, ~Submission.verified_fields.has_all(array(question_codes))), 'Flagged'), # noqa
+            (and_(qa_query == True, ~Submission.verified_fields.has_all(array(question_codes))), 'Flagged'),    # noqa
             (and_(qa_query == True, Submission.verified_fields.has_all(array(question_codes))), 'Verified'),    # noqa
-            (and_(qa_query == False, 'OK'), # noqa
+            (qa_query == False, 'OK'), # noqa
             (qa_query == None, 'Missing')
         ])
     else:


### PR DESCRIPTION
this pull request attempts to resolve nditech/apollo-issues#36 by inverting the logic of entered QA checks. prior to this, the expression for the condition to _*pass*_ QA is entered into the system.
with this pull request, the condition to _*fail*_ QA is entered in.
furthermore, this pull request also changes the colours used for rendering the QA dashboard chart to match with what is used in the QA list view.