### PR TITLE
evaluate QA as having missing data...

### DIFF
--- a/apollo/frontend/filters.py
+++ b/apollo/frontend/filters.py
@@ -229,7 +229,7 @@ class QualityAssuranceFilter(ChoiceFilter):
 
                     filter_query = None
 
-                    if condition == '4':
+                    if condition == FLAG_CHOICES[3][0]:
                         # verified
                         if tags:
                             filter_query = and_(
@@ -242,14 +242,14 @@ class QualityAssuranceFilter(ChoiceFilter):
                                 single_qa_query == False,  # noqa
                                 false()
                             )
-                    elif condition == '-1':
+                    elif condition == FLAG_CHOICES[1][0]:
                         # missing
                             filter_query = (single_qa_query == None)    # noqa
-                    elif condition == '0':
-                        # ok
-                        filter_query = (single_qa_query == True)        # noqa
-                    elif condition == '2':
+                    elif condition == FLAG_CHOICES[0][0]:
                         # flagged
+                        filter_query = (single_qa_query == True)        # noqa
+                    elif condition == FLAG_CHOICES[2][0]:
+                        # ok
                         if tags:
                             filter_query = and_(
                                 single_qa_query == False,  # noqa
@@ -280,7 +280,7 @@ class QualityAssuranceFilter(ChoiceFilter):
             question_codes = array(tags)
 
             condition = value['condition']
-            if condition == '4':
+            if condition == FLAG_CHOICES[3][0]:
                 # verified
                 if tags:
                     return query.filter(
@@ -291,14 +291,14 @@ class QualityAssuranceFilter(ChoiceFilter):
                     return query.filter(
                         qa_subquery == False,  # noqa
                         false())
-            elif condition == '-1':
+            elif condition == FLAG_CHOICES[1][0]:
                 # missing
                 return query.filter(qa_subquery == None)  # noqa
-            elif condition == '0':
-                # OK
-                return query.filter(qa_subquery == True)  # noqa
-            elif condition == '2':
+            elif condition == FLAG_CHOICES[0][0]:
                 # flagged
+                return query.filter(qa_subquery == True)  # noqa
+            elif condition == FLAG_CHOICES[2][0]:
+                # OK
                 if tags:
                     return query.filter(
                         qa_subquery == False,   # noqa

--- a/apollo/frontend/filters.py
+++ b/apollo/frontend/filters.py
@@ -227,9 +227,8 @@ class QualityAssuranceFilter(ChoiceFilter):
                     single_qa_query, tags = generate_qa_query(
                         qa_expr, self.qa_form)
                     uses_null = 'null' in qa_expr.lower()
-                    if tags and uses_null:
-                        null_query = false()
-                    elif tags:
+
+                    if tags and uses_null is False:
                         null_query = or_(*[
                             models.Submission.data[tag] == None # noqa
                             for tag in tags])


### PR DESCRIPTION
...if _*ANY*_ of the fields used for the QA expression is having missing data, even if the QA expression can be evaluated without it.

see: nditech/apollo-issues#37
