### PR TITLE
fix segment navigation in the qa builder

### DIFF
--- a/apollo/static/js/selectize.js
+++ b/apollo/static/js/selectize.js
@@ -3684,34 +3684,6 @@
 			return index >= 0 && index < $options.length ? $options.eq(index) : $();
 		};
 	
-		this.onKeyDown = (function() {
-			var original = self.onKeyDown;
-			return function(e) {
-				var index, $option, $options, $optgroup;
-	
-				if (this.isOpen && (e.keyCode === KEY_LEFT || e.keyCode === KEY_RIGHT)) {
-					self.ignoreHover = true;
-					$optgroup = this.$activeOption.closest('[data-group]');
-					index = $optgroup.find('[data-selectable]').index(this.$activeOption);
-	
-					if(e.keyCode === KEY_LEFT) {
-						$optgroup = $optgroup.prev('[data-group]');
-					} else {
-						$optgroup = $optgroup.next('[data-group]');
-					}
-	
-					$options = $optgroup.find('[data-selectable]');
-					$option  = $options.eq(Math.min($options.length - 1, index));
-					if ($option.length) {
-						this.setActiveOption($option);
-					}
-					return;
-				}
-	
-				return original.apply(this, arguments);
-			};
-		})();
-	
 		var getScrollbarWidth = function() {
 			var div;
 			var width = getScrollbarWidth.width;


### PR DESCRIPTION
This PR fixes the navigation using the `left` and `right` keyboard arrow keys for the segments in the QA builder.