### PR TITLE
fix: replace legacy filter for results summary views

### DIFF
--- a/apollo/result_analysis/views_results.py
+++ b/apollo/result_analysis/views_results.py
@@ -13,9 +13,10 @@ from sqlalchemy import not_
 
 from apollo import models
 from apollo.formsframework.models import Form
-from apollo.frontend import route, permissions, filters
+from apollo.frontend import route, permissions
 from apollo.frontend.helpers import analysis_breadcrumb_data
 from apollo.services import forms, locations, location_types, submissions
+from apollo.submissions.filters import make_submission_analysis_filter
 from apollo.submissions.models import FLAG_STATUSES
 from apollo.submissions.utils import make_submission_dataframe
 
@@ -58,7 +59,7 @@ def _voting_results(form_id, location_id=None):
 
     template_name = 'result_analysis/results.html'
     breadcrumbs = [_('Results Data'), form.name]
-    filter_class = filters.generate_submission_analysis_filter(form)
+    filter_class = make_submission_analysis_filter(event, form)
 
     loc_types = [lt for lt in location_types.root(
                     event.location_set_id).descendants()


### PR DESCRIPTION
this commit replaces the legacy filter for results summary
with the current filter and addresses
nditech/apollo-issues#77

see: nditech/apollo-issues#77