### PR TITLE
fix: convert _LazyString to str

### DIFF
--- a/apollo/frontend/views_admin.py
+++ b/apollo/frontend/views_admin.py
@@ -396,7 +396,7 @@ class UserAdminView(BaseAdminView):
         for role in models.User.query.filter(models.User.id.in_(ids)):
             role.active = False
             role.save()
-        flash(_('User(s) successfully disabled.'), 'success')
+        flash(str(_('User(s) successfully disabled.')), 'success')
 
     @action('enable', _('Enable'),
             _('Are you sure you want to enable the selected users?'))
@@ -404,7 +404,7 @@ class UserAdminView(BaseAdminView):
         for role in models.User.query.filter(models.User.id.in_(ids)):
             role.active = True
             role.save()
-        flash(_('User(s) successfully enabled.'), 'success')
+        flash(str(_('User(s) successfully enabled.')), 'success')
 
 
 class RoleAdminView(BaseAdminView):

--- a/apollo/locations/views_locations.py
+++ b/apollo/locations/views_locations.py
@@ -247,9 +247,12 @@ def locations_builder(view, location_set_id):
         for unused_lt in unused_location_types:
             query = Location.query.filter(Location.location_type == unused_lt)
             if db.session.query(query.exists()).scalar():
-                flash(_('Administrative level %(name)s has locations assigned '
-                        'and cannot be deleted.', name=unused_lt.name),
-                      category='danger')
+                flash(
+                    str(
+                        _('Administrative level %(name)s has locations '
+                          'assigned and cannot be deleted.',
+                          name=unused_lt.name)),
+                    category='danger')
                 break
 
             # explicitly doing this because we didn't add a cascade
@@ -310,7 +313,7 @@ def import_divisions(location_set_id):
             graph = json.load(request.files['import_file'])
             import_graph(graph, location_set, fresh_import=True)
 
-            flash(_('Your changes have been saved.'), category='info')
+            flash(str(_('Your changes have been saved.')), category='info')
 
             return redirect(url_for('locationset.builder',
                                     location_set_id=location_set_id))


### PR DESCRIPTION
fixes nditech/apollo-issues#78 by converting `_LazyString` instances
(translated string references) to regular Python `str` instances before
passing to the `flash()` utility.

Unconverted `_LazyString` instances cannot be serialized to JSON, and
as such raise errors.

see: nditech/apollo-issues#78