### PR TITLE
feat: add transactions to location imports

### DIFF
--- a/apollo/helpers.py
+++ b/apollo/helpers.py
@@ -46,8 +46,8 @@ def load_source_file(source_file):
         # likely a CSV file
         df = pd.read_csv(source_file, dtype=str).fillna('')
     elif mimetype.startswith('application'):
-        # likely an Excel spreadsheet
-        df = pd.read_excel(source_file, 0).fillna('')
+        # likely an Excel spreadsheet, read all data as strings
+        df = pd.read_excel(source_file, 0, dtype=str).fillna('')
     else:
         raise RuntimeError('Unknown file type')
 


### PR DESCRIPTION
this pull request adds explicit transactions to locations import in order to deal with the recurrent issues encountered with imports
**Edit**
- nested transactions enabled. if any of the inner ones fails, the outermost one is rolled back
- import all data uploaded in Excel spreadsheets as strings