### PR TITLE
feat: remplement overlapping events

### DIFF
--- a/apollo/deployments/fixtures/17720ddbe13.sql
+++ b/apollo/deployments/fixtures/17720ddbe13.sql
@@ -1,10 +1,10 @@
-INSERT INTO public.deployment VALUES (1, 'Demo', '{localhost}', true, NULL, false, false, true, true, NULL, NULL, 'd1c8beb2-92f3-4d90-a3f7-bcbc3aeeda00');
-INSERT INTO public.resource VALUES (1, 'event', 1, '93f73f01-515d-46fc-a1c9-ec7b8a7c5087');
-INSERT INTO public.resource VALUES (2, 'event', 1, 'f1e22698-98da-4016-a158-b136da4f5372');
-INSERT INTO public.resource VALUES (3, 'event', 1, 'a6701a89-9e07-49a9-a19a-055bcc5ca1f4');
-INSERT INTO public.event VALUES (1, 'Event 1', '2005-12-13 01:00:00+01', '2005-12-14 00:59:59+01', 1, NULL, NULL);
-INSERT INTO public.event VALUES (2, 'Event 2', '2005-12-14 01:00:00+01', '2005-12-15 00:59:59+01', 2, NULL, NULL);
-INSERT INTO public.event VALUES (3, 'Event 3', '2005-12-14 01:00:00+01', '2005-12-16 00:59:59+01', 3, NULL, NULL);
+INSERT INTO public.deployment (id, name, hostnames, uuid) VALUES (1, 'Demo', '{localhost}', 'd1c8beb2-92f3-4d90-a3f7-bcbc3aeeda00');
+INSERT INTO public.resource (resource_id, resource_type, deployment_id, uuid) VALUES (1, 'event', 1, '93f73f01-515d-46fc-a1c9-ec7b8a7c5087');
+INSERT INTO public.resource (resource_id, resource_type, deployment_id, uuid) VALUES (2, 'event', 1, 'f1e22698-98da-4016-a158-b136da4f5372');
+INSERT INTO public.resource (resource_id, resource_type, deployment_id, uuid) VALUES (3, 'event', 1, 'a6701a89-9e07-49a9-a19a-055bcc5ca1f4');
+INSERT INTO public.event (id, name, start, "end", resource_id) VALUES (1, 'Event 1', '2005-12-13 01:00:00+01', '2005-12-14 00:59:59+01', 1);
+INSERT INTO public.event (id, name, start, "end", resource_id) VALUES (2, 'Event 2', '2005-12-14 01:00:00+01', '2005-12-15 00:59:59+01', 2);
+INSERT INTO public.event (id, name, start, "end", resource_id) VALUES (3, 'Event 3', '2005-12-14 01:00:00+01', '2005-12-16 00:59:59+01', 3);
 SELECT pg_catalog.setval('public.deployment_id_seq', 1, true);
 SELECT pg_catalog.setval('public.event_id_seq', 3, true);
 SELECT pg_catalog.setval('public.resource_resource_id_seq', 3, true);

--- a/apollo/deployments/models.py
+++ b/apollo/deployments/models.py
@@ -2,6 +2,7 @@
 from datetime import datetime
 
 from flask_babelex import gettext
+from sqlalchemy import and_, or_
 from sqlalchemy.dialects.postgresql import ARRAY
 
 from apollo.constants import LANGUAGES
@@ -87,3 +88,18 @@ class Event(Resource):
 
     def __str__(self):
         return gettext('Event - %(name)s', name=self.name)
+
+    @classmethod
+    def overlapping_events(cls, event, timestamp=None):
+        # return events overlapping with the specified event at
+        # the current or specified time, or return the specified event
+        # as a query
+        if timestamp is None:
+            timestamp = current_timestamp()
+
+        cond1 = cls.start <= timestamp
+        cond2 = cls.end >= timestamp
+        cond3 = cls.id == event.id
+        term = and_(cond1, cond2)
+
+        return cls.query.filter(or_(term, cond3))

--- a/apollo/deployments/models.py
+++ b/apollo/deployments/models.py
@@ -2,7 +2,6 @@
 from datetime import datetime
 
 from flask_babelex import gettext
-from sqlalchemy import and_, or_
 from sqlalchemy.dialects.postgresql import ARRAY
 
 from apollo.constants import LANGUAGES
@@ -88,18 +87,3 @@ class Event(Resource):
 
     def __str__(self):
         return gettext('Event - %(name)s', name=self.name)
-
-    @classmethod
-    def overlapping_events(cls, event, timestamp=None):
-        # return events overlapping with the specified event at
-        # the current or specified time, or return the specified event
-        # as a query
-        if timestamp is None:
-            timestamp = current_timestamp()
-
-        cond1 = cls.start <= timestamp
-        cond2 = cls.end >= timestamp
-        cond3 = cls.id == event.id
-        term = and_(cond1, cond2)
-
-        return cls.query.filter(or_(term, cond3))

--- a/apollo/deployments/services.py
+++ b/apollo/deployments/services.py
@@ -35,24 +35,5 @@ class EventService(Service):
 
         return None
 
-    def overlapping_events(self, event):
-        # case 1: all events completely contained within the timespan
-        # of the passed-in event
-        expr1 = and_(Event.start >= event.start, Event.end <= event.end)
-
-        # case 2: all events that start before the passed-in event,
-        # and end before it ends
-        expr2 = and_(Event.start <= event.start, Event.end >= event.start)
-
-        # case 3: all events that start during the passed-in event,
-        # and end after it
-        expr3 = and_(Event.start <= event.end, Event.end >= event.end)
-
-        overlapping = self.filter(
-            Event.deployment_id == event.deployment_id,
-            or_(expr1, expr2, expr3))
-
-        if overlapping.with_entities(Event.id).count() > 0:
-            return overlapping
-
-        return self.query.filter_by(id=event.id)
+    def overlapping_events(self, event, timestamp=None):
+        return self.__model__.overlapping_events(event, timestamp=timestamp)

--- a/apollo/deployments/services.py
+++ b/apollo/deployments/services.py
@@ -36,4 +36,15 @@ class EventService(Service):
         return None
 
     def overlapping_events(self, event, timestamp=None):
-        return self.__model__.overlapping_events(event, timestamp=timestamp)
+        # return events overlapping with the specified event at
+        # the current or specified time, or return the specified event
+        # as a query
+        if timestamp is None:
+            timestamp = current_timestamp()
+
+        cond1 = self.__model__.start <= timestamp
+        cond2 = self.__model__.end >= timestamp
+        cond3 = self.__model__.id == event.id
+        term = and_(cond1, cond2)
+
+        return self.__model__.query.filter(or_(term, cond3))

--- a/apollo/deployments/tests.py
+++ b/apollo/deployments/tests.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from datetime import datetime, timezone
 import pathlib
 from unittest import mock
 
@@ -26,8 +27,19 @@ class EventServiceTest(TestCase):
         fixtures_path = DEFAULT_FIXTURES_PATH / '17720ddbe13.sql'
         fixtures.load_sql_fixture(fixtures_path)
 
+        ##############################################################
+        #
+        #   start and end times:
+        #
+        #   event 1: 2005-12-13 01:00:00+01 - 2005-12-14 00:59:59+01
+        #   event 2: 2005-12-14 01:00:00+01 - 2005-12-15 00:59:59+01
+        #   event 3: 2005-12-14 01:00:00+01 - 2005-12-16 00:59:59+01
+        #
+        ##############################################################
+
         event1, event2, event3 = services.events.find().order_by('id').all()
 
+        # the 'no-overlap' case
         with mock.patch.object(
                 services.events, 'default', return_value=event1):
             event = services.events.default()
@@ -36,22 +48,27 @@ class EventServiceTest(TestCase):
             self.assertIn(event, events)
             self.assertEqual(len(events), 1)
 
+        # the overlap cases:
+        # 1 - at a time they do overlap
         with mock.patch.object(
                 services.events, 'default', return_value=event2):
             event = services.events.default()
-            events = services.events.overlapping_events(event).all()
+            timestamp = datetime(2005, 12, 14, 16, tzinfo=timezone.utc)
+            events = services.events.overlapping_events(event, timestamp).all()
 
             self.assertIn(event2, events)
             self.assertIn(event3, events)
             self.assertNotIn(event1, events)
             self.assertEqual(len(events), 2)
 
+        # 2 - at a time they do not overlap
         with mock.patch.object(
                 services.events, 'default', return_value=event3):
             event = services.events.default()
-            events = services.events.overlapping_events(event).all()
+            timestamp = datetime(2005, 12, 16, 2, tzinfo=timezone.utc)
+            events = services.events.overlapping_events(event, timestamp).all()
 
-            self.assertIn(event2, events)
             self.assertIn(event3, events)
             self.assertNotIn(event1, events)
-            self.assertEqual(len(events), 2)
+            self.assertNotIn(event2, events)
+            self.assertEqual(len(events), 1)


### PR DESCRIPTION
this commit changes the way overlapping events work

prior to this, we'd retrieve all events that intersect temporally
with a specified event

now, all events intersecting temporally with the specified
event at a specific timestamp (which defaults to the current timestamp)
are returned instead