### PR TITLE
mark quality assurance control description as safe

### DIFF
--- a/apollo/templates/admin/quality_assurance_edit.html
+++ b/apollo/templates/admin/quality_assurance_edit.html
@@ -282,7 +282,7 @@
       title: '{{ title }}',
       control: {
         name: '{{ quality_control.name }}',
-        description: '{{ quality_control.description }}',
+        description: '{{ quality_control.description | safe }}',
         criteria: {{ quality_control.criteria|tojson }}
       }
     },


### PR DESCRIPTION
This pull request marks the quality assurance control description as safe preventing the escaping of html entities. This is safe as it only gets used as the value of a html text input.

resolving nditech/apollo-issues#81