### PR TITLE
fix: remove the string 'nan' from Excel imports

### DIFF
--- a/apollo/helpers.py
+++ b/apollo/helpers.py
@@ -48,7 +48,7 @@ def load_source_file(source_file):
     elif mimetype.startswith('application'):
         # likely an Excel spreadsheet, read all data as strings
         xl = pd.ExcelFile(source_file)
-        ncols = xl.book.sheet_by_index(0)
+        ncols = xl.book.sheet_by_index(0).ncols
         df = xl.parse(0, converters={i: str for i in range(ncols)}).fillna('')
     else:
         raise RuntimeError('Unknown file type')

--- a/apollo/helpers.py
+++ b/apollo/helpers.py
@@ -47,7 +47,9 @@ def load_source_file(source_file):
         df = pd.read_csv(source_file, dtype=str).fillna('')
     elif mimetype.startswith('application'):
         # likely an Excel spreadsheet, read all data as strings
-        df = pd.read_excel(source_file, 0, dtype=str).fillna('')
+        xl = pd.ExcelFile(source_file)
+        ncols = xl.book.sheet_by_index(0)
+        df = xl.parse(0, converters={i: str for i in range(ncols)}).fillna('')
     else:
         raise RuntimeError('Unknown file type')
 


### PR DESCRIPTION
this commit fixes the issue where the value `nan` appears after importing an Excel file in fields that were empty.