### PR TITLE
feat: speed up process data summary

### DIFF
--- a/apollo/process_analysis/common.py
+++ b/apollo/process_analysis/common.py
@@ -429,15 +429,16 @@ def generate_field_stats(field, dataset, all_tags=None):
             field['tag'], dataset, field.get('expected', 0))
 
 
-def generate_incidents_data(form, queryset, location_root, grouped=True,
+def generate_incidents_data(data_frame, form, location_root, grouped=True,
                             tags=None):
     '''Generates process statistics for either a location and its descendants,
     or for a sample. Optionally generates statistics for an entire region, or
     for groups of regions.
 
     Parameters
+    - data_frame: a dataframe of submission data
+                  (generated from `make_submission_dataframe`)
     - form: a Form instance
-    - queryset: a queryset of submissions
     - location_root: a root location to retrieve statistics for
     - grouped: when retrieving statistics for a location, specify whether or
     not to retrieve statistics on a per-group basis.
@@ -455,12 +456,7 @@ def generate_incidents_data(form, queryset, location_root, grouped=True,
             if field['analysis_type'] != 'N/A'
         ]
 
-    try:
-        data_frame = make_submission_dataframe(queryset, form)
-
-        if data_frame.empty:
-            return incidents_summary
-    except Exception:
+    if data_frame.empty:
         return incidents_summary
 
     if grouped:
@@ -544,15 +540,16 @@ def generate_incidents_data(form, queryset, location_root, grouped=True,
     return incidents_summary
 
 
-def generate_process_data(form, queryset, location_root, grouped=True,
+def generate_process_data(data_frame, form, location_root, grouped=True,
                           tags=None):
     '''Generates process statistics for either a location and its descendants,
     or for a sample. Optionally generates statistics for an entire region, or
     for groups of regions.
 
     Parameters
+    - data_frame: a dataframe of submission data
+                  (generated from `make_submission_dataframe`)
     - form: a Form instance
-    - queryset: a queryset of submissions
     - location_root: a root location to retrieve statistics for
     - grouped: when retrieving statistics for a location, specify whether or
     not to retrieve statistics on a per-group basis.
@@ -570,12 +567,7 @@ def generate_process_data(form, queryset, location_root, grouped=True,
             if field['analysis_type'] != 'N/A'
         ]
 
-    try:
-        data_frame = make_submission_dataframe(queryset, form)
-
-        if data_frame.empty:
-            return process_summary
-    except Exception:
+    if data_frame.empty:
         return process_summary
 
     if grouped:

--- a/apollo/process_analysis/views_process.py
+++ b/apollo/process_analysis/views_process.py
@@ -160,7 +160,8 @@ def _process_analysis(event, form_id, location_id=None, tag=None):
 
     # set up template context
     context = {}
-    context['dataframe'] = make_submission_dataframe(filter_set.qs, form)
+    submission_dataframe = make_submission_dataframe(filter_set.qs, form)
+    context['dataframe'] = submission_dataframe
     context['breadcrumbs'] = breadcrumbs
     context['display_tag'] = display_tag
     context['filter_form'] = filter_set.form
@@ -179,7 +180,7 @@ def _process_analysis(event, form_id, location_id=None, tag=None):
             context['incidents'] = filter_set.qs
         else:
             incidents_summary = generate_incidents_data(
-                form, filter_set.qs, location, grouped, tags)
+                submission_dataframe, form, location, grouped, tags)
             context['incidents_summary'] = incidents_summary
 
         detail_visible = False
@@ -201,7 +202,7 @@ def _process_analysis(event, form_id, location_id=None, tag=None):
             context['field_groups'][group['name']] = process_fields
 
         process_summary = generate_process_data(
-            form, filter_set.qs, location, grouped=True, tags=tags)
+            submission_dataframe, form, location, grouped=True, tags=tags)
         context['process_summary'] = process_summary
 
     return render_template(template_name, **context)


### PR DESCRIPTION
this commit attempts to speed up process data summaries by:
- removing a duplicate call to an expensive function
  (`apollo.submissions.utils.make_submission_dataframe`)
  in process data summaries
- replacing a call to `pandas.DataFrame.apply(pandas.Series)` in
  the above function since it is slow. instead, the hierarchy
  is computed as a JSON object in PostgreSQL and loaded into
  the `pandas.DataFrame` using `pandas.read_sql()`, then 'split'
  using `pandas.io.json.json_normalize()`