### PR TITLE
fix: render QA description as a JSON string

### DIFF
--- a/apollo/templates/admin/quality_assurance_edit.html
+++ b/apollo/templates/admin/quality_assurance_edit.html
@@ -282,7 +282,7 @@
       title: '{{ title }}',
       control: {
         name: '{{ quality_control.name }}',
-        description: '{{ quality_control.description | safe }}',
+        description: {{ quality_control.description | tojson }},
         criteria: {{ quality_control.criteria|tojson }}
       }
     },


### PR DESCRIPTION
see: nditech/apollo-issues#105