### PR TITLE
chore: sort inputs to multiselect form fields

### DIFF
--- a/apollo/odk/views_odk.py
+++ b/apollo/odk/views_odk.py
@@ -217,7 +217,7 @@ def submission():
                 data[tag] = element.text
             elif field_type == 'multiselect':
                 try:
-                    data[tag] = [int(i) for i in element.text.split()]
+                    data[tag] = sorted(int(i) for i in element.text.split())
                 except ValueError:
                     continue
             elif field_type == 'location':


### PR DESCRIPTION
noticed that when posting submission data via SMS, the values for multiselect field types is sorted. adding the same for data submitted via ODK