### PR TITLE
fix: set scheme based on the setting `SSL_REQUIRED`

### DIFF
--- a/apollo/odk/utils.py
+++ b/apollo/odk/utils.py
@@ -9,6 +9,8 @@ import qrcode
 from PIL import Image
 from flask import url_for
 
+from apollo.settings import SSL_REQUIRED
+
 
 def make_message_text(form, participant, data):
     message_body = f'{form.prefix} {participant.participant_id}'
@@ -32,10 +34,12 @@ def make_message_text(form, participant, data):
 
 
 def generate_config_qr_code(participant=None):
+    scheme = 'https' if SSL_REQUIRED else 'http'
     settings = {
         'general': {
             'server_url': urljoin(
-                url_for('dashboard.index', _external=True), 'xforms'
+                url_for('dashboard.index', _external=True, _scheme=scheme),
+                'xforms'
             )
         },
         'admin': {}


### PR DESCRIPTION
the QR code generated uses an unsecured scheme (http://) by default
this commit forces the usage of a secured scheme (https://) when
the value of `SSL_REQUIRED` is set to true, which it is by default.

to remove this functionality, `SSL_REQUIRED` must be explicitly set
to false