### PR TITLE
Fix double quotes

### DIFF
--- a/apollo/process_analysis/common.py
+++ b/apollo/process_analysis/common.py
@@ -6,8 +6,6 @@ from operator import itemgetter
 import numpy as np
 import pandas as pd
 
-from apollo.submissions.utils import make_submission_dataframe
-
 
 def _default_zero():
     return 0

--- a/apollo/submissions/utils.py
+++ b/apollo/submissions/utils.py
@@ -57,7 +57,7 @@ def make_submission_dataframe(query, form, selected_tags=None,
     columns.append(own_loc.registered_voters.label(
         'registered_voters'))
     columns.append(
-        func.json_object(
+        func.jsonb_object(
             array_agg(sub_query.c.ancestor_type),
             array_agg(sub_query.c.ancestor_name),
         ).label('location_data')

--- a/apollo/submissions/utils.py
+++ b/apollo/submissions/utils.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 from pandas.io.json import json_normalize
 from sqlalchemy import String, cast, func
-from sqlalchemy.dialects.postgresql import array_agg, aggregate_order_by
+from sqlalchemy.dialects.postgresql import array_agg
 from sqlalchemy.orm import aliased
 
 from apollo.core import db
@@ -88,9 +88,14 @@ def make_submission_dataframe(query, form, selected_tags=None,
         dataframe_query.session.bind
     ).astype(type_coercions)
 
+    loc_data_df = json_normalize(
+        df['location_data']
+    ).replace('(^"|"$)', '', regex=True)
+    loc_data_df.columns = loc_data_df.columns.str.strip('"')
+
     df_summary = pd.concat([
         df.drop('location_data', axis=1),
-        json_normalize(df['location_data'])
+        loc_data_df
     ], axis=1, join_axes=[df.index])
 
     return df_summary


### PR DESCRIPTION
this pull request fixes an issue with an issue with data summaries, where breakdowns were not displayed.
the immediate cause is that PostgreSQL wraps each item of the result of the function
`array_agg` in double quotes, which eventually gets into the dataframe columns and
data. thus, when during data summary there is an attempt to group by a location
level (say, for example, LGA), the actual column is `'"LGA"'` and not `'LGA'` as expected.
since grouping by a location level is skipped if it does not exist in the dataframe,
breakdowns are not displayed.

this pull request replaces double quotes at the beginning or end of each location data
record in the data summary dataframe, and replaces all double quotes in the column
headers.