### PR TITLE
add single image uploads when editing submissions

### DIFF
--- a/apollo/frontend/templates/frontend/incident_add.html
+++ b/apollo/frontend/templates/frontend/incident_add.html
@@ -1,7 +1,7 @@
 {%- extends 'frontend/layout.html' -%}
 {%- from 'frontend/macros/submission_field_macros.html' import render_field -%}
 {% block content %}
-<form method="POST">
+<form method="POST" enctype="multipart/form-data">
 <input type="hidden" name="next" value="{% if request.environ.get('HTTP_REFERER') == request.url %}{{ url_for('submissions.submission_list', form_id=form.id) }}{% else %}{{ request.environ.get('HTTP_REFERER', url_for('submissions.submission_list', form_id=form.id)) }}{% endif %}" />
 {{ submission_form.csrf_token() }}
 <div class="table-responsive">
@@ -37,7 +37,7 @@
       <div class="card-body py-0 px-0">
         <table id="dataTable" class="table table-borderless mb-0 table-responsive">
           <tbody>
-          {% for field in group.fields if field['type'] != 'image' %}
+          {% for field in group.fields %}
             <tr>
               <td class="align-middle" style="width: 0.1%; white-space: nowrap;"><strong>{{ field.tag }}</strong></td>
               <td class="align-middle">
@@ -103,6 +103,28 @@
 {%- block scripts %}
 <script type="text/javascript" charset="utf-8">
   $(function(){
+    var fileChangeHandler;
+    fileChangeHandler = function (changeEventObj) {
+      var fileInput = changeEventObj.target;
+      var container = fileInput.parentElement;
+      var selectButton = container.children[1];
+      
+      if (fileInput.files.length) {
+        selectButton.classList.remove('btn-secondary');
+        selectButton.classList.add('btn-primary');
+      }
+
+      // detach event listener
+      fileInput.removeEventListener('change', fileChangeHandler);
+    };
+
+    $('[data-context="select_button"').click(function (eventObj) {
+      var button = eventObj.target;
+      var fileInput = button.parentElement.children[0];
+      fileInput.addEventListener('change', fileChangeHandler);
+      fileInput.click();
+    });
+
     var addIncidentLocationOptions = LocationOptions;
     var addIncidentParticipantOptions = ParticipantOptions;
     delete addIncidentParticipantOptions.allowClear;

--- a/apollo/frontend/templates/frontend/macros/submission_field_macros.html
+++ b/apollo/frontend/templates/frontend/macros/submission_field_macros.html
@@ -11,7 +11,7 @@
 {% elif field_type == 'image' %}
 <div>
 {{ form_field(class_=klass_, disabled=disabled, hidden=true, accepts="image/jpeg, image/png") }}
-<input type="button" class="btn btn-secondary" data-context="select_button" value="{% trans %}Choose File{% endtrans %}">
+<label class="btn btn-secondary w-100" data-context="select_button">{% trans %}Choose File{% endtrans %}<input type="file" data-context="hidden_file" accept=".jpg,.png,image/jpeg,image/png" hidden /></label>
 </div>
 {% else %}
 {{ form_field(class_=klass_, disabled=disabled) }}

--- a/apollo/frontend/templates/frontend/macros/submission_field_macros.html
+++ b/apollo/frontend/templates/frontend/macros/submission_field_macros.html
@@ -10,8 +10,10 @@
 {{ form_field(class_="custom-select " + klass_, disabled=disabled) }}
 {% elif field_type == 'image' %}
 <div>
-{{ form_field(class_=klass_, disabled=disabled, hidden=true, accepts="image/jpeg, image/png") }}
-<label class="btn btn-secondary w-100" data-context="select_button">{% trans %}Choose File{% endtrans %}<input type="file" data-context="hidden_file" accept=".jpg,.png,image/jpeg,image/png" hidden /></label>
+<label class="btn btn-secondary w-100" data-context="select_button">
+<span role="button" tabindex="0">{% trans %}Choose File{% endtrans %}</span>
+<input type="file" name="{{ form_field.name }}" id="{{ form_field.id }}" data-context="hidden_file" accept=".jpg,.png,image/jpeg,image/png" hidden />
+</label>
 </div>
 {% else %}
 {{ form_field(class_=klass_, disabled=disabled) }}

--- a/apollo/frontend/templates/frontend/macros/submission_field_macros.html
+++ b/apollo/frontend/templates/frontend/macros/submission_field_macros.html
@@ -8,6 +8,11 @@
 {% endfor %}
 {% elif field_type == 'select' %}
 {{ form_field(class_="custom-select " + klass_, disabled=disabled) }}
+{% elif field_type == 'image' %}
+<div>
+{{ form_field(class_=klass_, disabled=disabled, hidden=true, accepts="image/jpeg, image/png") }}
+<input type="button" class="btn btn-secondary" data-context="select_button" value="{% trans %}Select file{% endtrans %}">
+</div>
 {% else %}
 {{ form_field(class_=klass_, disabled=disabled) }}
 {% endif %}

--- a/apollo/frontend/templates/frontend/macros/submission_field_macros.html
+++ b/apollo/frontend/templates/frontend/macros/submission_field_macros.html
@@ -11,7 +11,7 @@
 {% elif field_type == 'image' %}
 <div>
 {{ form_field(class_=klass_, disabled=disabled, hidden=true, accepts="image/jpeg, image/png") }}
-<input type="button" class="btn btn-secondary" data-context="select_button" value="{% trans %}Choose file{% endtrans %}">
+<input type="button" class="btn btn-secondary" data-context="select_button" value="{% trans %}Choose File{% endtrans %}">
 </div>
 {% else %}
 {{ form_field(class_=klass_, disabled=disabled) }}

--- a/apollo/frontend/templates/frontend/macros/submission_field_macros.html
+++ b/apollo/frontend/templates/frontend/macros/submission_field_macros.html
@@ -11,7 +11,7 @@
 {% elif field_type == 'image' %}
 <div>
 {{ form_field(class_=klass_, disabled=disabled, hidden=true, accepts="image/jpeg, image/png") }}
-<input type="button" class="btn btn-secondary" data-context="select_button" value="{% trans %}Select file{% endtrans %}">
+<input type="button" class="btn btn-secondary" data-context="select_button" value="{% trans %}Choose file{% endtrans %}">
 </div>
 {% else %}
 {{ form_field(class_=klass_, disabled=disabled) }}

--- a/apollo/frontend/templates/frontend/submission_edit.html
+++ b/apollo/frontend/templates/frontend/submission_edit.html
@@ -171,6 +171,7 @@
 {%- endif %}
 
 {%- if form.form_type in ['CHECKLIST', 'SURVEY'] %}
+{%- set num_forms = ((sibling_forms|count) + (2 if master_form else 1)) -%}
 {%- if master_form.errors or submission_form.errors %}
 <div class="alert alert-danger alert-dismissible fade show mt-4 mb-0" role="alert">
   <h5 class="alert-heading">{{ _('Data Validation Errors') }}</h5>

--- a/apollo/frontend/templates/frontend/submission_edit.html
+++ b/apollo/frontend/templates/frontend/submission_edit.html
@@ -584,7 +584,7 @@
       <div class="card-body py-0 px-0">
         <table class="table table-borderless mb-0 table-responsive">
           <tbody>
-          {% for field in group.fields if field['type'] != 'image' %}
+          {% for field in group.fields %}
             <tr>
               <td class="align-middle" style="width: 0.1%; white-space: nowrap;"><strong>{{ field.tag }}</strong></td>
               <td class="align-middle">{{ field.description }}</td>
@@ -704,7 +704,6 @@
       var fileInput = button.parentElement.children[0];
       fileInput.addEventListener('change', fileChangeHandler);
       fileInput.click();
-      // fileInput.removeEventListener('input', fileChangeHandler);
     });
 
     $('.tonow').each(function (index) {

--- a/apollo/frontend/templates/frontend/submission_edit.html
+++ b/apollo/frontend/templates/frontend/submission_edit.html
@@ -676,19 +676,14 @@
 <script type="text/javascript">
   moment.lang('{{ g.locale }}');
 
-  var fileChangeHandler;
-  fileChangeHandler = function (changeEventObj) {
+  var fileChangeHandler = function (changeEventObj) {
     var fileInput = changeEventObj.target;
-    var container = fileInput.parentElement;
-    var selectButton = container.children[1];
+    var label = fileInput.parentElement;
     
     if (fileInput.files.length) {
-      selectButton.classList.remove('btn-secondary');
-      selectButton.classList.add('btn-primary');
+      label.classList.remove('btn-secondary');
+      label.classList.add('btn-primary');
     }
-
-    // detach event listener
-    fileInput.removeEventListener('change', fileChangeHandler);
   };
 
   $(function () {
@@ -700,12 +695,7 @@
         slidesToScroll: 5
     });
 
-    $('[data-context="select_button"').click(function (eventObj) {
-      var button = eventObj.target;
-      var fileInput = button.parentElement.children[0];
-      fileInput.addEventListener('change', fileChangeHandler);
-      fileInput.click();
-    });
+    $('[data-context="hidden_file"]').on('change', fileChangeHandler);
 
     $('.tonow').each(function (index) {
       var timestamp = moment.unix(Number($(this).data('timestamp')));

--- a/apollo/frontend/templates/frontend/submission_edit.html
+++ b/apollo/frontend/templates/frontend/submission_edit.html
@@ -13,7 +13,7 @@
 
 
 {%- block content %}
-<form method="POST">
+<form method="POST" enctype="multipart/form-data">
 <input type="hidden" name="next" value="{% if request.environ.get('HTTP_REFERER') == request.url %}{{ url_for('submissions.submission_list', form_id=form.id) }}{% else %}{{ request.environ.get('HTTP_REFERER', url_for('submissions.submission_list', form_id=form.id)) }}{% endif %}" />
 {{ submission_form.csrf_token() }}
 {%- if form.form_type in ['CHECKLIST', 'SURVEY'] %}
@@ -302,14 +302,14 @@
         <h5 class="mb-0">{{ group.name }}</h5>
       </div>
       {# check for data validation or quality assurance errors #}
-      {%- for field in group.fields if field['type'] != 'image' %}
+      {%- for field in group.fields %}
       {%- if submission_form[field.tag].errors %}{% set ns.has_form_error = true %}{% endif %}
       {%- if field.tag in failed_check_tags and submission.form.quality_checks_enabled and perms.edit_submission_verification_status.can() -%}{% set ns.has_qa_error = true %}{% endif %}
       {%- endfor %}
       <div id="grp{{ loop.index }}" class="card-body {% if submission.completion(group.name) == 'Complete' and not ns.has_form_error and not ns.has_qa_error %} collapse{% else %} show{% endif %} py-0 px-0">
         <table class="table table-borderless mb-0 table-responsive">
           <tbody>
-          {% for field in group.fields if field['type'] != 'image' %}
+          {% for field in group.fields %}
             <tr {%- if field.tag in failed_check_tags and submission.form.quality_checks_enabled and field.tag not in submission.verified_fields and perms.edit_submission_verification_status.can() %} class="bg-warning"{% endif %}>
               <td class="align-middle" style="width: 0.1%; white-space: nowrap;"><strong>{{ field.tag }}</strong></td>
               <td class="align-middle obs-on">
@@ -324,15 +324,15 @@
                 </div>
               </td>
               {% if readonly -%}
-              <td class="col-2 align-middle obs-on"><label for="{{ submission_form[field.tag].id }}" class="sr-only">{{ submission_form[field.tag].label.text }}</label>{{ render_field(submission_form[field.tag], field.type, klass_='form-control tracked text-monospace', disabled='disabled') }}</td>
+              <td class="col-2 align-middle obs-on" {% if field['type'] == 'image' %}colspan="{{ num_forms }}"{% endif %}><label for="{{ submission_form[field.tag].id }}" class="sr-only">{{ submission_form[field.tag].label.text }}</label>{{ render_field(submission_form[field.tag], field.type, klass_='form-control tracked text-monospace', disabled='disabled') }}</td>
               {%- else -%}
               {% if submission_form[field.tag].errors -%}
-              <td class="col-2 align-middle obs-on"><label for="{{ submission_form[field.tag].id }}" class="sr-only">{{ submission_form[field.tag].label.text }}</label>{{ render_field(submission_form[field.tag], field.type, klass_='form-control tracked text-monospace is-invalid') }}</td>
+              <td class="col-2 align-middle obs-on" {% if field['type'] == 'image' %}colspan="{{ num_forms }}"{% endif %}><label for="{{ submission_form[field.tag].id }}" class="sr-only">{{ submission_form[field.tag].label.text }}</label>{{ render_field(submission_form[field.tag], field.type, klass_='form-control tracked text-monospace is-invalid') }}</td>
               {%- else -%}
-              <td class="col-2 align-middle obs-on"><label for="{{ submission_form[field.tag].id }}" class="sr-only">{{ submission_form[field.tag].label.text }}</label>{{ render_field(submission_form[field.tag], field.type, klass_='form-control tracked text-monospace') }}</td>
+              <td class="col-2 align-middle obs-on" {% if field['type'] == 'image' %}colspan="{{ num_forms }}"{% endif %}><label for="{{ submission_form[field.tag].id }}" class="sr-only">{{ submission_form[field.tag].label.text }}</label>{{ render_field(submission_form[field.tag], field.type, klass_='form-control tracked text-monospace') }}</td>
               {%- endif %}
               {%- endif %}
-              {%- if form.form_type == 'CHECKLIST' and not form.untrack_data_conflicts -%}
+              {%- if form.form_type == 'CHECKLIST' and not form.untrack_data_conflicts and field['type'] != 'image' -%}
               {% for sibling_form in sibling_forms -%}
               <td class="col-2 align-middle"><label for="{{ sibling_form[field.tag].id }}" class="sr-only">{{ sibling_form[field.tag].label.text }}</label>{{ render_field(sibling_form[field.tag], field.type, klass_='form-control tracked text-monospace', disabled='disabled') }}</td>
               {% endfor %}
@@ -675,6 +675,22 @@
 <script type="text/javascript">
   moment.lang('{{ g.locale }}');
 
+  var fileChangeHandler;
+  fileChangeHandler = function (changeEventObj) {
+    var fileInput = changeEventObj.target;
+    var container = fileInput.parentElement;
+    var selectButton = container.children[1];
+    
+    if (fileInput.files.length) {
+      selectButton.classList.remove('btn-secondary');
+      selectButton.classList.add('btn-success');
+      selectButton.value = '{% trans %}File selected{% endtrans %}';
+    }
+
+    // detach event listener
+    fileInput.removeEventListener('change', fileChangeHandler);
+  };
+
   $(function () {
     $('[data-toggle="tooltip"]').tooltip();
     $('.slick').slick({
@@ -684,21 +700,29 @@
         slidesToScroll: 5
     });
 
+    $('[data-context="select_button"').click(function (eventObj) {
+      var button = eventObj.target;
+      var fileInput = button.parentElement.children[0];
+      fileInput.addEventListener('change', fileChangeHandler);
+      fileInput.click();
+      // fileInput.removeEventListener('input', fileChangeHandler);
+    });
+
     $('.tonow').each(function (index) {
       var timestamp = moment.unix(Number($(this).data('timestamp')));
       this.innerText = timestamp.fromNow();
     });
     $('.timestamp-date').each(function (index) {
-        var timestamp = moment.unix(Number($(this).data('timestamp')));
-        this.innerText = timestamp.format('ll');
+      var timestamp = moment.unix(Number($(this).data('timestamp')));
+      this.innerText = timestamp.format('ll');
     });
     $('.timestamp-time').each(function (index) {
-        var timestamp = moment.unix(Number($(this).data('timestamp')));
-        this.innerText = timestamp.format('LT');
+      var timestamp = moment.unix(Number($(this).data('timestamp')));
+      this.innerText = timestamp.format('LT');
     });
 
     // provide warning before navigating away if form was modified
-    $(document).on('change', '.tracked', function(e){
+    $(document).on('change', '.tracked', function(e) {
       window.onbeforeunload = function () { return true; };
     });
 

--- a/apollo/frontend/templates/frontend/submission_edit.html
+++ b/apollo/frontend/templates/frontend/submission_edit.html
@@ -696,6 +696,15 @@
     });
 
     $('[data-context="hidden_file"]').on('change', fileChangeHandler);
+    $('label > span[role="button"').bind('keypress keyup', function (evt) {
+      if (evt.which === 32 || evt.which === 13) {
+        evt.preventDefault();
+        var spanButton = this;
+        var fileInput = spanButton.parentElement.children[1];
+        console.log(fileInput);
+        fileInput.click();
+      }
+    });
 
     $('.tonow').each(function (index) {
       var timestamp = moment.unix(Number($(this).data('timestamp')));

--- a/apollo/frontend/templates/frontend/submission_edit.html
+++ b/apollo/frontend/templates/frontend/submission_edit.html
@@ -683,8 +683,7 @@
     
     if (fileInput.files.length) {
       selectButton.classList.remove('btn-secondary');
-      selectButton.classList.add('btn-success');
-      selectButton.value = '{% trans %}File selected{% endtrans %}';
+      selectButton.classList.add('btn-primary');
     }
 
     // detach event listener

--- a/apollo/submissions/forms.py
+++ b/apollo/submissions/forms.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from flask_babelex import lazy_gettext as _
 from flask_wtf import FlaskForm
+from flask_wtf.file import FileAllowed, FileField
 from wtforms import fields, validators, widgets
 from wtforms_alchemy.fields import QuerySelectField
 
@@ -146,6 +147,17 @@ def make_submission_edit_form_class(event, form):
                             filters=[lambda data: data if data else None],
                             validators=[validators.Optional()]
                         )
+                elif field_type == 'image':
+                    form_fields[field['tag']] = FileField(
+                        field['tag'],
+                        description=field['description'],
+                        validators=[
+                            FileAllowed(
+                                ['jpg', 'png'],
+                                _('Only JPG/PNG images supported')
+                            )
+                        ]
+                    )
                 else:
                     if field_type in ('category', 'integer'):
                         form_fields[field['tag']] = fields.IntegerField(

--- a/apollo/submissions/forms.py
+++ b/apollo/submissions/forms.py
@@ -154,7 +154,7 @@ def make_submission_edit_form_class(event, form):
                         validators=[
                             FileAllowed(
                                 ['jpg', 'png'],
-                                _('Only JPG/PNG images supported')
+                                _('Please select a JPG or PNG image to upload'),
                             )
                         ]
                     )

--- a/apollo/submissions/views_submissions.py
+++ b/apollo/submissions/views_submissions.py
@@ -702,6 +702,11 @@ def submission_edit(submission_id):
         else:
             master_form = None
 
+        if master_form is None:
+            num_forms = len(sibling_forms) + 1
+        else:
+            num_forms = len(sibling_forms) + 2
+
         return render_template(
             template_name,
             breadcrumbs=breadcrumbs,
@@ -709,6 +714,7 @@ def submission_edit(submission_id):
             submission_form=submission_form,
             sibling_forms=sibling_forms,
             master_form=master_form,
+            num_forms=num_forms,
             readonly=readonly,
             location_types=location_types,
             comments=comments,
@@ -1030,6 +1036,10 @@ def submission_edit(submission_id):
                         form_id=str(questionnaire_form.id)
                     ))
             else:
+                if master_form is None:
+                    num_forms = len(sibling_forms) + 1
+                else:
+                    num_forms = len(sibling_forms) + 2
                 return render_template(
                     template_name,
                     breadcrumbs=breadcrumbs,
@@ -1037,6 +1047,7 @@ def submission_edit(submission_id):
                     submission_form=submission_form,
                     master_form=master_form,
                     sibling_forms=sibling_forms,
+                    num_forms=num_forms,
                     readonly=readonly,
                     location_types=location_types,
                     comments=comments,

--- a/apollo/submissions/views_submissions.py
+++ b/apollo/submissions/views_submissions.py
@@ -198,7 +198,7 @@ def submission_list(form_id):
 
             # only change the submission type if we are aggregating data
             # and are not tracking conflicts
-            if mode == 'aggregated' and form.untrack_data_conflicts == True:    # noqa
+            if mode == 'aggregated' and form.untrack_data_conflicts == True:  # noqa
                 submission_type = 'O'
 
             queryset = query.filter(

--- a/apollo/submissions/views_submissions.py
+++ b/apollo/submissions/views_submissions.py
@@ -804,7 +804,7 @@ def submission_edit(submission_id):
                                     uuid=identifier
                                 ))
                     elif submission.data.get(form_field) != field_value:
-                        if field_value is None:
+                        if field_value is None and questionnaire_field['type'] != 'image':
                             data.pop(form_field, None)
                         else:
                             data[form_field] = field_value
@@ -1100,7 +1100,9 @@ def submission_edit(submission_id):
                         if data.get(form_field) != \
                                 submission_form.data.get(form_field):
                             if (
-                                submission_form.data.get(form_field) is None
+                                (submission_form.data.get(form_field) is None)
+                                and
+                                questionnaire_field['type'] != 'image'
                             ):
                                 data.pop(form_field, None)
                                 changed_fields.append(form_field)

--- a/apollo/submissions/views_submissions.py
+++ b/apollo/submissions/views_submissions.py
@@ -732,11 +732,6 @@ def submission_edit(submission_id):
         else:
             master_form = None
 
-        if master_form is None:
-            num_forms = len(sibling_forms) + 1
-        else:
-            num_forms = len(sibling_forms) + 2
-
         return render_template(
             template_name,
             breadcrumbs=breadcrumbs,
@@ -744,7 +739,6 @@ def submission_edit(submission_id):
             submission_form=submission_form,
             sibling_forms=sibling_forms,
             master_form=master_form,
-            num_forms=num_forms,
             readonly=readonly,
             location_types=location_types,
             comments=comments,
@@ -804,7 +798,10 @@ def submission_edit(submission_id):
                                     uuid=identifier
                                 ))
                     elif submission.data.get(form_field) != field_value:
-                        if field_value is None and questionnaire_field['type'] != 'image':
+                        if (
+                            field_value is None and
+                            questionnaire_field['type'] != 'image'
+                        ):
                             data.pop(form_field, None)
                         else:
                             data[form_field] = field_value
@@ -1146,10 +1143,6 @@ def submission_edit(submission_id):
                         form_id=str(questionnaire_form.id)
                     ))
             else:
-                if master_form is None:
-                    num_forms = len(sibling_forms) + 1
-                else:
-                    num_forms = len(sibling_forms) + 2
                 return render_template(
                     template_name,
                     breadcrumbs=breadcrumbs,
@@ -1157,7 +1150,6 @@ def submission_edit(submission_id):
                     submission_form=submission_form,
                     master_form=master_form,
                     sibling_forms=sibling_forms,
-                    num_forms=num_forms,
                     readonly=readonly,
                     location_types=location_types,
                     comments=comments,
@@ -1687,7 +1679,7 @@ def update_submission_version(submission):
 @auth.login_required
 def submission_export(form_id):
     form = services.forms.get_or_404(id=form_id)
-    if form.untrack_data_conflicts == True:
+    if form.untrack_data_conflicts == True:  # noqa
         submission_type = 'O'
     else:
         submission_type = 'M'


### PR DESCRIPTION
adds support for uploading images for observer submissions (checklists, incidents, surveys).