### PR TITLE
feat: show only first question for incident list

### DIFF
--- a/apollo/submissions/views_submissions.py
+++ b/apollo/submissions/views_submissions.py
@@ -468,12 +468,9 @@ def submission_list(form_id):
         form_fields = []
         breadcrumbs = [_("Surveys"), form.name]
     else:
-        if form.data and 'groups' in form.data:
-            form_fields = [
-                field for group in form.data['groups']
-                for field in group['fields'] if not field.get('is_comment')]
-        else:
-            form_fields = []
+        # show only the first question in the incident form
+        tags = form.tags
+        form_fields = [form.get_field_by_tag(tags[0])] if tags else []
         breadcrumbs = [_("Critical Incidents"), form.name]
 
     return render_template(


### PR DESCRIPTION
this commit renders only the first question in the critical incident
list view.

see: nditech/apollo-issues#28