### PR TITLE
make re-saved phone number primary

### DIFF
--- a/apollo/participants/views_participants.py
+++ b/apollo/participants/views_participants.py
@@ -483,6 +483,7 @@ def participant_edit(id, participant_set_id=0, view=None):
                 # (primary is the most recently updated and
                 # verified phone number)
                 phone.verified = True
+                phone.updated = utils.current_timestamp()
             phone.save()
 
             participant.password = form.password.data


### PR DESCRIPTION
When an existing phone number is re-saved, it should become the primary number. This was not previously done because the object did not have any attributes that had changed. The fix for this is to update the `updated` field with the current timestamp.