### PR TITLE
Minor fixes

### DIFF
--- a/apollo/locations/views_locations.py
+++ b/apollo/locations/views_locations.py
@@ -283,10 +283,11 @@ def locations_builder(view, location_set_id):
 
 def finalize_location_set(location_set_id):
     location_set = LocationSet.query.get_or_404(location_set_id)
-    _save_location_graph(location_set)
-    LocationSet.query.filter(LocationSet.id == location_set_id).update({
-        'is_finalized': True})
-    db.session.commit()
+    if request.form.get('divisions_graph'):
+        _save_location_graph(location_set)
+        LocationSet.query.filter(LocationSet.id == location_set_id).update({
+            'is_finalized': True})
+        db.session.commit()
     return redirect(url_for('locationset.builder',
                     location_set_id=location_set_id))
 

--- a/apollo/submissions/filters.py
+++ b/apollo/submissions/filters.py
@@ -526,6 +526,8 @@ class QualityAssuranceFilter(ChoiceFilter):
                             return query.filter(false())
 
                         qa_subqueries.append(filter_query)
+                else:
+                    return query.filter(false())
 
                 return query.filter(or_(*qa_subqueries))
 

--- a/apollo/submissions/filters.py
+++ b/apollo/submissions/filters.py
@@ -496,7 +496,7 @@ class QualityAssuranceFilter(ChoiceFilter):
                             # have all fields verified, and none are missing
                             term1 = (single_qa_query == True)   # noqa
                             if tags:
-                                term2 = models.Submission.verified_fields.has_all(
+                                term2 = models.Submission.verified_fields.has_all(      # noqa
                                     array(tags))
                             else:
                                 term2 = false()
@@ -510,14 +510,14 @@ class QualityAssuranceFilter(ChoiceFilter):
                             # verified, and none of them are missing
                             term1 = (single_qa_query == True)   # noqa
                             if tags:
-                                term2 = ~models.Submission.verified_fields.has_all(
+                                term2 = ~models.Submission.verified_fields.has_all(     # noqa
                                     array(tags))
                             else:
                                 term2 = true()
 
                             filter_query = and_(term1, term2, null_query == False)  # noqa
                         elif condition == FLAG_CHOICES[2][0]:
-                            # ok: checklist passes QA and none of the fields are
+                            # ok: checklist passes QA and none of the fields are    # noqa
                             # missing
                             filter_query = and_(
                                 single_qa_query == False, null_query == False)  # noqa


### PR DESCRIPTION
this pull request attempts to fix some issues that came up during usage:
- a user attempted to filter by a QA condition when there was no QA set up, and it resulted in a crash. this gracefully returns no records
- a user attempted to finalize a location set which apparently didn't have any divisions set up. this makes it a no-op
- trying to use QA on a numeric field which can take more than 9 digits exceeds the range of the `integer` data type. such data is cast to `biginteger` instead for QA