### PR TITLE
fix: don't error out exports when no groups exist

### DIFF
--- a/apollo/locations/services.py
+++ b/apollo/locations/services.py
@@ -83,7 +83,7 @@ class LocationService(Service):
         output.close()
 
         for row in query2:
-            location = row[0]
+            location = row[0] if groups else row
             record = []
             ancestors = LocationPath.query.filter(
                 LocationPath.depth > 0,


### PR DESCRIPTION
this pull request fixes an issue with exporting locations when no groups are defined.