### PR TITLE
fix: render single division in division builder

### DIFF
--- a/apollo/locations/models.py
+++ b/apollo/locations/models.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from itertools import chain
-
 from flask_babelex import gettext, lazy_gettext as _
 from geoalchemy2 import Geometry
 import networkx as nx
@@ -31,11 +29,13 @@ class LocationSet(BaseModel):
         return self.name or ''
 
     def make_admin_divisions_graph(self):
-        nodes = list(chain.from_iterable(
-            LocationType.query.filter(
+        location_type_map = {
+            lt.id: lt
+            for lt in LocationType.query.filter(
                 LocationType.location_set_id == self.id
-            ).with_entities(LocationType.id).all()
-        ))
+            )
+        }
+        nodes = location_type_map.keys()
         edges = LocationTypePath.query.filter(
             LocationTypePath.location_set_id == self.id,
             LocationTypePath.depth == 1
@@ -46,7 +46,7 @@ class LocationSet(BaseModel):
             LocationTypePath.ancestor_id,
             LocationTypePath.descendant_id,
             LocationTypePath.depth,
-        )
+        ).all()
 
         di_graph = nx.DiGraph()
         di_graph.add_nodes_from(nodes)
@@ -54,10 +54,7 @@ class LocationSet(BaseModel):
         sorted_nodes = list(nx.topological_sort(di_graph))
         sorted_edges = list(di_graph.edges(sorted_nodes))
 
-        location_types = [LocationType.query.filter(
-            LocationType.location_set_id == self.id,
-            LocationType.id == _id).one() for _id in sorted_nodes]
-
+        subset = [location_type_map.get(node) for node in sorted_nodes]
         nodes = [{
             'id': lt.id,
             'name': lt.name,
@@ -69,7 +66,7 @@ class LocationSet(BaseModel):
             'has_coordinates': lt.has_coordinates,
             'is_administrative': lt.is_administrative,
             'is_political': lt.is_political,
-        } for lt in location_types]
+        } for lt in subset]
 
         graph = {
             'nodes': nodes,

--- a/apollo/locations/models.py
+++ b/apollo/locations/models.py
@@ -38,12 +38,15 @@ class LocationSet(BaseModel):
         ))
         edges = LocationTypePath.query.filter(
             LocationTypePath.location_set_id == self.id,
-            LocationTypePath.depth != 0,
-            LocationTypePath.ancestor_id != LocationTypePath.descendant_id,
+            LocationTypePath.depth == 1
         ).with_entities(
             LocationTypePath.ancestor_id,
             LocationTypePath.descendant_id
-        ).all()
+        ).order_by(
+            LocationTypePath.ancestor_id,
+            LocationTypePath.descendant_id,
+            LocationTypePath.depth,
+        )
 
         di_graph = nx.DiGraph()
         di_graph.add_nodes_from(nodes)


### PR DESCRIPTION
fixes an issue with the location divisions builder where if only one division is in the tree, it does not get rendered.