### PR TITLE
fix: use a subquery to filter by participant role

### DIFF
--- a/apollo/submissions/filters.py
+++ b/apollo/submissions/filters.py
@@ -133,20 +133,16 @@ def make_participant_role_filter(participant_set_id):
             if value:
                 joined_classes = [
                     mapper.class_ for mapper in query._join_entities]
-                if models.Participant in joined_classes:
-                    query1 = query
-                else:
-                    query1 = query.join(models.Submission.participant)
+                if models.Participant not in joined_classes:
+                    query = query.join(models.Submission.participant)
 
-                if models.ParticipantRole in joined_classes:
-                    query2 = query1
-                else:
-                    query2 = query1.join(
+                if models.ParticipantRole not in joined_classes:
+                    query = query.join(
                         models.ParticipantRole,
                         models.Participant.role_id == models.ParticipantRole.id
                     )
 
-                return query2.filter(models.ParticipantRole.id == value)
+                return query.filter(models.ParticipantRole.id == value)
 
             return query
 

--- a/apollo/submissions/filters.py
+++ b/apollo/submissions/filters.py
@@ -131,7 +131,12 @@ def make_participant_role_filter(participant_set_id):
 
         def queryset_(self, query, value, **kwargs):
             if value:
-                return query.filter_by(role_id=value)
+                subquery = models.Participant.query.filter(
+                    models.Participant.participant_set_id == participant_set_id,  # noqa
+                    models.Participant.role_id == value
+                ).with_entities(models.Participant.id).subquery()
+                return query.filter(
+                    models.Submission.participant_id.in_(subquery))
 
             return query
 


### PR DESCRIPTION
when viewing a list of submissions and it gets filtered by a
participant role, the filter works, but errors out when one exports.
This commit fixes that by using a conditional join to the participant
and participant role tables, and does not assume that the
participant role table is joined to the main query (which is the case
when viewing the list, but not when exporting).

see: nditech/apollo-issues#166