### PR TITLE
feat: run event deletion in the worker

### DIFF
--- a/apollo/deployments/tasks.py
+++ b/apollo/deployments/tasks.py
@@ -14,28 +14,42 @@ def delete_event(event_pk: int) -> None:
 
     engine = db.get_engine()
 
-    # create a transaction
-    with engine.begin() as connection:
-        # generate the SQL statements to delete:
-        # - messages (linked to the event)
-        messages_delete_st = messages_table.delete().where(
-            messages_table.c.event_id == event_pk
-        )
-        # - submissions (linked to the event)
-        submissions_delete_st = submissions_table.delete().where(
-            submissions_table.c.event_id == event_pk
-        )
-        # - the event itself
-        event_delete_st = events_table.delete().where(
-            events_table.c.id == event_pk
-        )
+    try:
+        # create a transaction. an exception while the context manager is
+        # active will cause the transaction to be rolled back, and the
+        # exception will be propagated outwards
+        with engine.begin() as connection:
+            # generate the SQL statements to delete:
+            # - messages (linked to the event)
+            messages_delete_st = messages_table.delete().where(
+                messages_table.c.event_id == event_pk
+            )
+            # - submissions (linked to the event)
+            submissions_delete_st = submissions_table.delete().where(
+                submissions_table.c.event_id == event_pk
+            )
+            # - the event itself
+            event_delete_st = events_table.delete().where(
+                events_table.c.id == event_pk
+            )
 
-        # delete each in a sub-transaction
-        with connection.begin():
-            connection.execute(messages_delete_st)
+            # delete each in a sub-transaction
+            try:
+                with connection.begin():
+                    connection.execute(messages_delete_st)
+            except Exception:
+                return
 
-        with connection.begin():
-            connection.execute(submissions_delete_st)
+            try:
+                with connection.begin():
+                    connection.execute(submissions_delete_st)
+            except Exception:
+                return
 
-        with connection.begin():
-            connection.execute(event_delete_st)
+            try:
+                with connection.begin():
+                    connection.execute(event_delete_st)
+            except Exception:
+                return
+    except Exception:
+        return

--- a/apollo/deployments/tasks.py
+++ b/apollo/deployments/tasks.py
@@ -38,18 +38,18 @@ def delete_event(event_pk: int) -> None:
                 with connection.begin():
                     connection.execute(messages_delete_st)
             except Exception:
-                return
+                raise
 
             try:
                 with connection.begin():
                     connection.execute(submissions_delete_st)
             except Exception:
-                return
+                raise
 
             try:
                 with connection.begin():
                     connection.execute(event_delete_st)
             except Exception:
-                return
+                raise
     except Exception:
         return

--- a/apollo/deployments/tasks.py
+++ b/apollo/deployments/tasks.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from apollo import models
+from apollo.core import db
+from apollo.factory import create_celery_app
+
+celery = create_celery_app()
+
+
+@celery.task
+def delete_event(event_pk: int) -> None:
+    events_table = models.Event.__table__
+    messages_table = models.Message.__table__
+    submissions_table = models.Submission.__table__
+
+    engine = db.get_engine()
+
+    # create a transaction
+    with engine.begin() as connection:
+        # generate the SQL statements to delete:
+        # - messages (linked to the event)
+        messages_delete_st = messages_table.delete().where(
+            messages_table.c.event_id == event_pk
+        )
+        # - submissions (linked to the event)
+        submissions_delete_st = submissions_table.delete().where(
+            submissions_table.c.event_id == event_pk
+        )
+        # - the event itself
+        event_delete_st = events_table.delete().where(
+            events_table.c.id == event_pk
+        )
+
+        # delete each in a sub-transaction
+        with connection.begin():
+            connection.execute(messages_delete_st)
+
+        with connection.begin():
+            connection.execute(submissions_delete_st)
+
+        with connection.begin():
+            connection.execute(event_delete_st)

--- a/apollo/frontend/views_admin.py
+++ b/apollo/frontend/views_admin.py
@@ -388,13 +388,13 @@ class EventAdminView(BaseAdminView):
         if event_count > 1:
             # don't delete the event the user is using
             if model == g.event:
-                message = str(_('Cannot delete the current event'))
+                message = str(_("You cannot delete the current event"))
                 flash(message, 'danger')
                 return False
 
             # run event deletion task asynchronously
             delete_event.delay(model.id)
-            message = str(_("Selected event(s) marked for deletion"))
+            message = str(_("The selected event(s) are now scheduled for deletion"))
             flash(message, 'info')
             return True
         else:

--- a/apollo/tasks.py
+++ b/apollo/tasks.py
@@ -3,8 +3,9 @@ from apollo.factory import create_celery_app
 
 celery = create_celery_app()
 
-from apollo.formsframework.tasks import update_submissions
-from apollo.messaging.tasks import send_messages, send_email
-from apollo.participants.tasks import import_participants
-from apollo.locations.tasks import import_locations
-from apollo.submissions.tasks import init_submissions
+from apollo.deployments.tasks import delete_event  # noqa
+from apollo.formsframework.tasks import update_submissions  # noqa
+from apollo.messaging.tasks import send_messages, send_email  # noqa
+from apollo.participants.tasks import import_participants  # noqa
+from apollo.locations.tasks import import_locations  # noqa
+from apollo.submissions.tasks import init_submissions  # noqa


### PR DESCRIPTION
this PR addresses nditech/apollo-issues#168 by moving the deletion
out of the web process and into the worker process.
The deletion is done using SQLAlchemy Core, not the ORM.
Finally, a restriction against deleting an event in use by the
initiating admin user is put in place.

see: nditech/apollo-issues#168