### PR TITLE
Deal with improper handling of CSV imports

### DIFF
--- a/apollo/constants.py
+++ b/apollo/constants.py
@@ -11,17 +11,3 @@ BOM_UTF8_STR = str(BOM_UTF8_BYTES, 'utf-8')
 
 LANGUAGE_CHOICES = [('', _('(None)'))] + \
     sorted(LANGUAGES.items(), key=itemgetter(0))
-
-CSV_MIMETYPES = [
-    "text/csv",
-    "application/csv",
-    "text/x-csv",
-    "application/x-csv",
-    "text/comma-separated-values",
-    "text/x-comma-separated-values",
-]
-
-EXCEL_MIMETYPES = [
-    "application/vnd.ms-excel",
-    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-]

--- a/apollo/constants.py
+++ b/apollo/constants.py
@@ -11,3 +11,17 @@ BOM_UTF8_STR = str(BOM_UTF8_BYTES, 'utf-8')
 
 LANGUAGE_CHOICES = [('', _('(None)'))] + \
     sorted(LANGUAGES.items(), key=itemgetter(0))
+
+CSV_MIMETYPES = [
+    "text/csv",
+    "application/csv",
+    "text/x-csv",
+    "application/x-csv",
+    "text/comma-separated-values",
+    "text/x-comma-separated-values",
+]
+
+EXCEL_MIMETYPES = [
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+]

--- a/apollo/formsframework/utils.py
+++ b/apollo/formsframework/utils.py
@@ -3,7 +3,6 @@ import logging
 import re
 
 from pyxform import xls2json
-from pyxform.errors import PyXFormError
 from slugify import slugify
 from xlwt import Workbook
 
@@ -219,10 +218,7 @@ def _process_qa_worksheet(qa_data):
 
 
 def import_form(sourcefile):
-    try:
-        file_data = xls2json.xls_to_dict(sourcefile)
-    except PyXFormError:
-        logger.exception('Error parsing Excel schema file')
+    file_data = xls2json.xls_to_dict(sourcefile)
 
     survey_data = file_data.get('survey')
     choices_data = file_data.get('choices')

--- a/apollo/helpers.py
+++ b/apollo/helpers.py
@@ -6,6 +6,8 @@ import magic
 import pandas as pd
 import pkgutil
 
+from .constants import CSV_MIMETYPES, EXCEL_MIMETYPES
+
 
 def register_blueprints(app, package_name, package_path):
     """Register all Blueprint instances on the specified Flask application
@@ -42,10 +44,10 @@ def load_source_file(source_file):
     mimetype = magic.from_buffer(source_file.read(), mime=True)
     source_file.seek(0)
 
-    if 'csv' in mimetype or mimetype.startswith('text/'):
+    if mimetype in CSV_MIMETYPES:
         # likely a CSV file
         df = pd.read_csv(source_file, dtype=str).fillna('')
-    elif mimetype.startswith('application'):
+    elif mimetype in EXCEL_MIMETYPES:
         # likely an Excel spreadsheet, read all data as strings
         xl = pd.ExcelFile(source_file)
         ncols = xl.book.sheet_by_index(0).ncols

--- a/apollo/helpers.py
+++ b/apollo/helpers.py
@@ -6,7 +6,19 @@ import magic
 import pandas as pd
 import pkgutil
 
-from .constants import CSV_MIMETYPES, EXCEL_MIMETYPES
+CSV_MIMETYPES = [
+    "text/csv",
+    "application/csv",
+    "text/x-csv",
+    "application/x-csv",
+    "text/comma-separated-values",
+    "text/x-comma-separated-values",
+]
+
+EXCEL_MIMETYPES = [
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+]
 
 
 def register_blueprints(app, package_name, package_path):

--- a/apollo/helpers.py
+++ b/apollo/helpers.py
@@ -42,7 +42,7 @@ def load_source_file(source_file):
     mimetype = magic.from_buffer(source_file.read(), mime=True)
     source_file.seek(0)
 
-    if mimetype.startswith('text'):
+    if 'csv' in mimetype or mimetype.startswith('text/'):
         # likely a CSV file
         df = pd.read_csv(source_file, dtype=str).fillna('')
     elif mimetype.startswith('application'):


### PR DESCRIPTION
This PR changes the processing of upload file mimetypes so that when a CSV mimetype is returned with the prefix `application/` instead of the more common `text/`, it is not processed (incorrectly) as an Excel spreadsheet.

Related to nditech/apollo-issues#163