### PR TITLE
fix: do not coalesce values from fields

### DIFF
--- a/apollo/submissions/utils.py
+++ b/apollo/submissions/utils.py
@@ -32,9 +32,7 @@ def make_submission_dataframe(query, form, selected_tags=None,
 
     columns = [
         cast(
-            func.coalesce(
-                func.nullif(Submission.data[tag].astext, ''),
-                '0'),
+            func.nullif(Submission.data[tag].astext, ''),
             BigInteger).label(tag) for tag in integral_fields]
     other_fields = fields.difference(integral_fields)
 


### PR DESCRIPTION
this commit fixes an issue that arises with data summary on single-choice questions when data summary is viewed. records that originally had no data would have that replaced by 0 and break data summary as a result.