### PR TITLE
fix: correct usage of jsonify with HTTP status

### DIFF
--- a/apollo/api/hooks.py
+++ b/apollo/api/hooks.py
@@ -8,24 +8,30 @@ from apollo.core import red
 
 
 def process_expired_token(jwt_header, jwt_payload):
-    return jsonify({
+    response = jsonify({
         'status': _('error'),
         'message': _('Token has expired')
-    }), HTTPStatus.UNAUTHORIZED
+    })
+    response.status_code = HTTPStatus.UNAUTHORIZED
+    return response
 
 
 def process_invalid_token(reason):
-    return jsonify({
+    response = jsonify({
         'status': _('error'),
         'message': _(reason)
-    }), HTTPStatus.UNPROCESSABLE_ENTITY
+    })
+    response.status_code = HTTPStatus.UNPROCESSABLE_ENTITY
+    return response
 
 
 def process_revoked_token(jwt_header, jwt_payload):
-    return jsonify({
+    response = jsonify({
         'status': _('error'),
         'message': _('Token has been revoked')
-    }), HTTPStatus.UNAUTHORIZED
+    })
+    response.status_code = HTTPStatus.UNAUTHORIZED
+    return response
 
 
 def check_if_token_is_blocklisted(jwt_header, jwt_payload):

--- a/apollo/participants/api/views.py
+++ b/apollo/participants/api/views.py
@@ -150,11 +150,11 @@ def login():
     ).first()
 
     if participant is None:
-        response = {'message': gettext('Login failed'), 'status': 'error'}
-        rv = jsonify(response)
-        rv.status_code = HTTPStatus.FORBIDDEN
+        response_body = {'message': gettext('Login failed'), 'status': 'error'}
+        response = jsonify(response_body)
+        response.status_code = HTTPStatus.FORBIDDEN
 
-        return rv
+        return response
 
     access_token = create_access_token(
         identity=str(participant.uuid), fresh=True)
@@ -164,7 +164,7 @@ def login():
     send_jwts_in_response = 'cookies' not in settings.JWT_TOKEN_LOCATION or \
         (request.headers.get('X-TOKEN-IN-BODY') is not None)
 
-    response = {
+    response_body = {
         'data': {
             'participant': {
                 'events': [ev.id for ev in participant.participant_set.events],
@@ -181,11 +181,11 @@ def login():
     }
 
     if send_jwts_in_response:
-        response['data'].update(access_token=access_token)
+        response_body['data'].update(access_token=access_token)
 
-        return jsonify(response)
+        return jsonify(response_body)
 
-    resp = jsonify(response)
+    resp = jsonify(response_body)
     set_access_cookies(resp, access_token)
 
     return resp
@@ -200,16 +200,16 @@ def logout():
     # unset cookies if they are used
     unset_cookies = 'cookies' in settings.JWT_TOKEN_LOCATION
 
-    response = {
+    response_body = {
         'status': 'ok',
         'message': gettext('Logged out successfully')
     }
-    resp = jsonify(response)
+    response = jsonify(response_body)
 
     if unset_cookies:
-        unset_access_cookies(resp)
+        unset_access_cookies(response)
 
-    return resp
+    return response
 
 
 def _get_form_data(participant):
@@ -257,20 +257,20 @@ def get_forms():
     try:
         participant = Participant.query.filter_by(uuid=participant_uuid).one()
     except NoResultFound:
-        response = {
+        response_body = {
             'message': gettext('Invalid participant'),
             'status': 'error'
         }
 
-        rv = jsonify(response)
-        rv.status_code = HTTPStatus.BAD_REQUEST
-        return rv
+        response = jsonify(response_body)
+        response.status_code = HTTPStatus.BAD_REQUEST
+        return response
 
     forms, serials = _get_form_data(participant)
 
     form_data = FormSchema(many=True).dump(forms).data
 
-    result = {
+    response_body = {
         'data': {
             'forms': form_data,
             'serials': serials,
@@ -279,4 +279,4 @@ def get_forms():
         'status': 'ok'
     }
 
-    return jsonify(result)
+    return jsonify(response_body)

--- a/apollo/participants/api/views.py
+++ b/apollo/participants/api/views.py
@@ -151,7 +151,10 @@ def login():
 
     if participant is None:
         response = {'message': gettext('Login failed'), 'status': 'error'}
-        return jsonify(response), HTTPStatus.FORBIDDEN
+        rv = jsonify(response)
+        rv.status_code = HTTPStatus.FORBIDDEN
+
+        return rv
 
     access_token = create_access_token(
         identity=str(participant.uuid), fresh=True)
@@ -259,7 +262,9 @@ def get_forms():
             'status': 'error'
         }
 
-        return jsonify(response), HTTPStatus.BAD_REQUEST
+        rv = jsonify(response)
+        rv.status_code = HTTPStatus.BAD_REQUEST
+        return rv
 
     forms, serials = _get_form_data(participant)
 

--- a/apollo/submissions/api/views.py
+++ b/apollo/submissions/api/views.py
@@ -133,7 +133,9 @@ def checklist_qa_status(uuid):
             'status': 'error'
         }
 
-        return jsonify(response), HTTPStatus.BAD_REQUEST
+        rv = jsonify(response)
+        rv.status_code = HTTPStatus.BAD_REQUEST
+        return rv
 
     try:
         submission = Submission.query.filter_by(
@@ -144,7 +146,9 @@ def checklist_qa_status(uuid):
             'status': 'error'
         }
 
-        return jsonify(response), HTTPStatus.BAD_REQUEST
+        rv = jsonify(response)
+        rv.status_code = HTTPStatus.BAD_REQUEST
+        return rv
 
     form = submission.form
     submission_qa_status = [
@@ -172,7 +176,9 @@ def submission():
             'status': 'error'
         }
 
-        return jsonify(response), HTTPStatus.BAD_REQUEST
+        rv = jsonify(response)
+        rv.status_code = HTTPStatus.BAD_REQUEST
+        return rv
 
     form_id = request_data.get('form')
     form_serial = request_data.get('serial')
@@ -186,7 +192,9 @@ def submission():
             'status': 'error'
         }
 
-        return jsonify(response), HTTPStatus.BAD_REQUEST
+        rv = jsonify(response)
+        rv.status_code = HTTPStatus.BAD_REQUEST
+        return rv
 
     try:
         participant = Participant.query.filter_by(uuid=participant_uuid).one()
@@ -196,7 +204,9 @@ def submission():
             'status': 'error'
         }
 
-        return jsonify(response), HTTPStatus.BAD_REQUEST
+        rv = jsonify(response)
+        rv.status_code = HTTPStatus.BAD_REQUEST
+        return rv
 
     participant = filter_participants(form, participant.participant_id)
     if participant is None:
@@ -205,7 +215,9 @@ def submission():
             'status': 'error'
         }
 
-        return jsonify(response), HTTPStatus.BAD_REQUEST
+        rv = jsonify(response)
+        rv.status_code = HTTPStatus.BAD_REQUEST
+        return rv
 
     # validate payload
     schema_class = form.create_schema()
@@ -219,7 +231,9 @@ def submission():
             'errorFields': error_fields,
         }
 
-        return jsonify(response), HTTPStatus.BAD_REQUEST
+        rv = jsonify(response)
+        rv.status_code = HTTPStatus.BAD_REQUEST
+        return rv
 
     current_event = getattr(g, 'event', Event.default())
     current_events = Event.overlapping_events(current_event)
@@ -272,7 +286,9 @@ def submission():
             'message': gettext('Could not update data. Please check your ID'),
             'status': 'error'
         }
-        return jsonify(response), HTTPStatus.BAD_REQUEST
+        rv = jsonify(response)
+        rv.status_code = HTTPStatus.BAD_REQUEST
+        return rv
 
     data = submission.data.copy() if submission.data else {}
     payload2 = payload.copy()

--- a/apollo/submissions/api/views.py
+++ b/apollo/submissions/api/views.py
@@ -128,27 +128,27 @@ def checklist_qa_status(uuid):
     try:
         participant = Participant.query.filter_by(uuid=participant_uuid).one()
     except NoResultFound:
-        response = {
+        response_body = {
             'message': gettext('Invalid participant'),
             'status': 'error'
         }
 
-        rv = jsonify(response)
-        rv.status_code = HTTPStatus.BAD_REQUEST
-        return rv
+        response = jsonify(response_body)
+        response.status_code = HTTPStatus.BAD_REQUEST
+        return response
 
     try:
         submission = Submission.query.filter_by(
             uuid=uuid, participant_id=participant.id).one()
     except NoResultFound:
-        response = {
+        response_body = {
             'message': gettext('Invalid checklist'),
             'status': 'error'
         }
 
-        rv = jsonify(response)
-        rv.status_code = HTTPStatus.BAD_REQUEST
-        return rv
+        response = jsonify(response_body)
+        response.status_code = HTTPStatus.BAD_REQUEST
+        return response
 
     form = submission.form
     submission_qa_status = [
@@ -156,13 +156,13 @@ def checklist_qa_status(uuid):
         if form.quality_checks else []
     passed_qa = QUALITY_STATUSES['FLAGGED'] not in submission_qa_status
 
-    response = {
+    response_body = {
         'message': gettext('Ok'),
         'status': 'ok',
         'passedQA': passed_qa
     }
 
-    return jsonify(response)
+    return jsonify(response_body)
 
 
 @csrf.exempt
@@ -171,14 +171,14 @@ def submission():
     try:
         request_data = json.loads(request.form.get('submission'))
     except Exception:
-        response = {
+        response_body = {
             'message': gettext('Invalid data sent'),
             'status': 'error'
         }
 
-        rv = jsonify(response)
-        rv.status_code = HTTPStatus.BAD_REQUEST
-        return rv
+        response = jsonify(response_body)
+        response.status_code = HTTPStatus.BAD_REQUEST
+        return response
 
     form_id = request_data.get('form')
     form_serial = request_data.get('serial')
@@ -187,53 +187,53 @@ def submission():
 
     form = filter_form(form_id)
     if form is None:
-        response = {
+        response_body = {
             'message': gettext('Invalid form'),
             'status': 'error'
         }
 
-        rv = jsonify(response)
-        rv.status_code = HTTPStatus.BAD_REQUEST
-        return rv
+        response = jsonify(response_body)
+        response.status_code = HTTPStatus.BAD_REQUEST
+        return response
 
     try:
         participant = Participant.query.filter_by(uuid=participant_uuid).one()
     except NoResultFound:
-        response = {
+        response_body = {
             'message': gettext('Invalid participant'),
             'status': 'error'
         }
 
-        rv = jsonify(response)
-        rv.status_code = HTTPStatus.BAD_REQUEST
-        return rv
+        response = jsonify(response_body)
+        response.status_code = HTTPStatus.BAD_REQUEST
+        return response
 
     participant = filter_participants(form, participant.participant_id)
     if participant is None:
-        response = {
+        response_body = {
             'message': gettext('Invalid participant'),
             'status': 'error'
         }
 
-        rv = jsonify(response)
-        rv.status_code = HTTPStatus.BAD_REQUEST
-        return rv
+        response = jsonify(response_body)
+        response.status_code = HTTPStatus.BAD_REQUEST
+        return response
 
     # validate payload
     schema_class = form.create_schema()
     data, errors = schema_class().load(payload)
     if errors:
         error_fields = sorted(errors.keys())
-        response = {
+        response_body = {
             'message': gettext('Invalid value(s) for: %(fields)s',
                                fields=','.join(error_fields)),
             'status': 'error',
             'errorFields': error_fields,
         }
 
-        rv = jsonify(response)
-        rv.status_code = HTTPStatus.BAD_REQUEST
-        return rv
+        response = jsonify(response_body)
+        response.status_code = HTTPStatus.BAD_REQUEST
+        return response
 
     current_event = getattr(g, 'event', Event.default())
     current_events = Event.overlapping_events(current_event)
@@ -282,13 +282,13 @@ def submission():
 
     # if submission is None, there's no submission
     if submission is None:
-        response = {
+        response_body = {
             'message': gettext('Could not update data. Please check your ID'),
             'status': 'error'
         }
-        rv = jsonify(response)
-        rv.status_code = HTTPStatus.BAD_REQUEST
-        return rv
+        response = jsonify(response_body)
+        response.status_code = HTTPStatus.BAD_REQUEST
+        return response
 
     data = submission.data.copy() if submission.data else {}
     payload2 = payload.copy()
@@ -392,7 +392,7 @@ def submission():
 
     # return the submission ID so that any updates
     # (for example, sending attachments) can be done
-    response = {
+    response_body = {
         'message': gettext('Data successfully submitted'),
         'status': 'ok',
         'submission': submission.id,
@@ -401,4 +401,4 @@ def submission():
         '_id': submission.uuid,
     }
 
-    return jsonify(response)
+    return jsonify(response_body)


### PR DESCRIPTION
this pull request seeks to correct the usage of `jsonify()` with a HTTP status code. `jsonify()` returns a Flask `Response`, so to use it with a return code, rather than return a tuple of `<response_content>`, `<HTTP status code>`, one should set the `status_code` property of the result from `jsonify()`