### PR TITLE
this is an improvement on how the convergence chart is plotted

### DIFF
--- a/apollo/formsframework/forms.py
+++ b/apollo/formsframework/forms.py
@@ -320,6 +320,18 @@ class BaseQuestionnaireForm(wtforms.Form):
                         update_params['data'] = data
                         update_params['last_phone_number'] = phone_num
                         update_params['participant_updated'] = current_timestamp()  # noqa
+
+                        # set the 'voting_timestamp' extra data attribute to
+                        # the current timestamp only if a voting share was
+                        # updated and it has not been previously set
+                        if (
+                            any(vs in data.keys() for vs in submission.form.vote_shares)  # noqa
+                            and not (submission.extra_data or {}).get('voting_timestamp')  # noqa
+                        ):
+                            extra_data = submission.extra_data or {}
+                            extra_data['voting_timestamp'] = current_timestamp().isoformat()  # noqa
+                            update_params['extra_data'] = extra_data
+
                         services.submissions.find(
                             id=submission.id
                         ).update(update_params, synchronize_session=False)

--- a/apollo/odk/views_odk.py
+++ b/apollo/odk/views_odk.py
@@ -266,6 +266,16 @@ def submission():
         submission.geom = 'SRID=4326; POINT({longitude:f} {latitude:f})'.format(    # noqa
             longitude=geopoint_lon, latitude=geopoint_lat)
 
+    # set the 'voting_timestamp' extra data attribute to the current timestamp
+    # only if a voting share was updated and it has not been previously set
+    if (
+        any(vs in data.keys() for vs in submission.form.vote_shares)
+        and not (submission.extra_data or {}).get('voting_timestamp')
+    ):
+        extra_data = submission.extra_data or {}
+        extra_data['voting_timestamp'] = current_timestamp().isoformat()
+        submission.extra_data = extra_data
+
     db.session.add(submission)
     db.session.add_all(attachments)
     for attachment in deleted_attachments:


### PR DESCRIPTION
now rather than using when the submission was last updated, we track the first time any fields that are vote shares were updated and use that instead.

see nditech/apollo-issues#32