### PR TITLE
fix labels don't active input element

### DIFF
--- a/apollo/pwa/static/js/serviceworker.js
+++ b/apollo/pwa/static/js/serviceworker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'apollo-cache-static-v8';
+const CACHE_NAME = 'apollo-cache-static-v9';
 
 const CACHED_URLS = [
   '/pwa/',

--- a/apollo/pwa/templates/pwa/index.html
+++ b/apollo/pwa/templates/pwa/index.html
@@ -206,15 +206,17 @@
                       <div class="mb-3" v-else-if="field.type === 'select'">
                         <label :for="field.tag" class="form-label"><span class="fw-bold">[[ field.tag ]]</span> [[ field.description ]]</label>
                         <div class="form-check" v-for="{value, label} in sortOptions(field.options)">
-                          <label :for="field.tag" class="form-label">[[ label ]]</label>
+                          <label :for="field.tag + '_' + value"  class="form-label">[[ label ]]
                           <input type="radio" :name="field.tag" :id="field.tag + '_' + value" class="form-check-input" :value="value" v-model="data[field.tag]" :disabled="locked" @change="markUpdated">
+                          </label>
                         </div>
                       </div>
                       <div class="mb-3" v-else-if="field.type === 'multiselect'">
                         <label :for="field.tag" class="form-label"><span class="fw-bold">[[ field.tag ]]</span> [[ field.description ]]</label>
                         <div class="form-check" v-for="{value, label} in sortOptions(field.options)">
-                          <label :for="field.tag" class="form-label">[[ label ]]</label>
+                          <label :for="field.tag + '_' + value" class="form-label">[[ label ]]
                           <input type="checkbox" name="field.tag" :id="field.tag + '_' + value" class="form-check-input" :value="value" v-model="data[field.tag]" :disabled="locked" @change="markUpdated">
+                          </label>
                         </div>
                       </div>
                       <div class="mb-3" v-else-if="field.type === 'string'">


### PR DESCRIPTION
This PR is a small fix to allowing the labels on input elements in the PWA to also activate the input element when they are clicked on

resolves nditech/apollo-issues#195