### PR TITLE
fix: prevent submitting decimal values in the PWA

### DIFF
--- a/apollo/pwa/templates/pwa/index.html
+++ b/apollo/pwa/templates/pwa/index.html
@@ -840,7 +840,7 @@
           });
 
           if (errorFields.length > 0) {
-            let errorMessage = '{{ _("Please check that you did not a value out of bounds or a decimal number for the following question(s)") }}: ' + errorFields.join();
+            let errorMessage = '{{ _("Please check that you did not enter a value out of bounds or a decimal number for the following question(s)") }}: ' + errorFields.join();
             Notiflix.Report.Failure(
               '{{ _("Error") }}',
               errorMessage,

--- a/apollo/pwa/templates/pwa/index.html
+++ b/apollo/pwa/templates/pwa/index.html
@@ -840,7 +840,7 @@
           });
 
           if (errorFields.length > 0) {
-            let errorMessage = '{{ _("Please check that you did not enter a value out of bounds or a decimal number for the following question(s)") }}: ' + errorFields.join();
+            let errorMessage = '{{ _("Please check what you entered into the following fields") }}: ' + errorFields.join();
             Notiflix.Report.Failure(
               '{{ _("Error") }}',
               errorMessage,

--- a/apollo/pwa/templates/pwa/index.html
+++ b/apollo/pwa/templates/pwa/index.html
@@ -833,12 +833,14 @@
               if (instance.data[field.tag] !== undefined || instance.data[field.tag] !== null) {
                 if ((fieldData < field.min) || (fieldData > field.max))
                   errorFields.push(field.tag);
+                else if (Number.parseInt(fieldData.toString()) !== fieldData)
+                  errorFields.push(field.tag);
               }
             });
           });
 
           if (errorFields.length > 0) {
-            let errorMessage = '{{ _("Please check what you entered into the following fields") }}: ' + errorFields.join();
+            let errorMessage = '{{ _("Please check that you did not a value out of bounds or a decimal number for the following question(s)") }}: ' + errorFields.join();
             Notiflix.Report.Failure(
               '{{ _("Error") }}',
               errorMessage,

--- a/apollo/submissions/api/views.py
+++ b/apollo/submissions/api/views.py
@@ -308,6 +308,14 @@ def submission():
                     payload2[tag] = sorted(value)
                 except Exception:
                     pass
+        elif field['type'] == 'integer':
+            value = payload.get('tag')
+            if value is not None:
+                try:
+                    payload2[tag] = int(value)
+                except ValueError:
+                    # invalid value
+                    payload2.pop(tag, None)
 
     attachments = []
     deleted_attachments = []


### PR DESCRIPTION
the PR asks the user to review what they entered into a numeric data field in the PWA if it is not convertible to an exact integral value.

see: nditech/apollo-issues#199