### PR TITLE
feat: add participant count to checklist creation

### DIFF
--- a/apollo/participants/views_participants.py
+++ b/apollo/participants/views_participants.py
@@ -57,6 +57,11 @@ bp.add_url_rule(
     '/api/participants/',
     view_func=api_views.ParticipantListResource.as_view(
         'api_participant_list'))
+bp.add_url_rule(
+    '/api/participant_count/',
+    endpoint='api_participant_count',
+    view_func=api_views.get_participant_count,
+)
 
 docs.register(
     api_views.ParticipantItemResource, 'participants.api_participant_item')

--- a/apollo/templates/admin/form_list.html
+++ b/apollo/templates/admin/form_list.html
@@ -184,7 +184,7 @@
       <div class="form-group row align-items-center">
         <label class="col-sm-4 control-label text-right mb-0 required" for="event">{{ init_form.event.label.text }}</label>
         <div class="col-sm-8">
-          <select id="event" class="form-control custom-select" name="event" v-model="event">
+          <select id="event" class="form-control custom-select" name="event" v-model="event" @change="getParticipantCount">
             <option value="">{{ _('Choose Event') }}</option>
             <option v-for="event in this.$parent.events" :value="event.id" :key="event.id">{{ '{{' }} event.name {{ '}}' }}</option>
           </select>
@@ -202,7 +202,7 @@
       <div class="form-group row align-items-center">
         <label class="col-sm-4 control-label text-right mb-0 required" for="role">{{ init_form.role.label.text }}</label>
         <div class="col-sm-8">
-          <select id="role" class="form-control custom-select" name="role">
+          <select id="role" class="form-control custom-select" name="role" v-model="role" @change="getParticipantCount">
             <option value="">{{ _('Choose Role') }}</option>
             <option v-for="role in roles" :value="role.id" :key="role.id">{{ '{{' }} role.name {{ '}}' }}</option>
           </select>
@@ -211,10 +211,16 @@
       <div class="form-group row align-items-center">
         <label class="col-sm-4 control-label text-right mb-0 required" for="location_type">{{ init_form.location_type.label.text }}</label>
         <div class="col-sm-8">
-          <select id="location_type" class="form-control custom-select" name="location_type">
+          <select id="location_type" class="form-control custom-select" name="location_type" v-model="level" @change="getParticipantCount">
             <option value="">{{ _('Choose Location Type') }}</option>
             <option v-for="location_type in location_types" :value="location_type.id" :key="location_type.id">{{ '{{' }} location_type.name {{ '}}' }}</option>
           </select>
+        </div>
+      </div>
+      <div class="form-group row align-items-center">
+        <label class="col-sm-4 control-label text-right mb-0">{{ _('Number of participants') }}</label>
+        <div class="col-sm-8">
+          <input class="form-control" disabled="true" :value="participantCount" />
         </div>
       </div>
     </div>
@@ -222,6 +228,9 @@
     data: function() {
       return {
         event: '',
+        role: '',
+        level: '',
+        participantCount: 'N/A'
       }
     },
     computed: {
@@ -243,6 +252,38 @@
           return location_type.events.indexOf(event) == -1 ? false : true;
         });
       },
+    },
+    methods: {
+      getParticipantCount() {
+        const endpoint = '{{ url_for("participants.api_participant_count") }}?';
+        eventId = this.event;
+        levelId = this.level;
+        roleId = this.role;
+
+        let params = new URLSearchParams();
+        if (eventId) {
+          params.append('event_id', eventId);
+        }
+
+        if (levelId) {
+          params.append('level_id', levelId);
+        }
+
+        if (roleId) {
+          params.append('role_id', roleId);
+        }
+
+        const instance = this;
+        fetch(endpoint + params)
+          .then(response => response.json())
+          .then(result => {
+            if (result.participants) {
+              instance.participantCount = result.participants;
+            } else {
+              instance.participantCount = 'N/A';
+            }
+          })
+      }
     }
   });
 

--- a/apollo/templates/admin/form_list.html
+++ b/apollo/templates/admin/form_list.html
@@ -277,7 +277,7 @@
         fetch(endpoint + params)
           .then(response => response.json())
           .then(result => {
-            if (result.participants) {
+            if (result.participants !== null) {
               instance.participantCount = result.participants;
             } else {
               instance.participantCount = 'N/A';

--- a/apollo/templates/admin/form_list.html
+++ b/apollo/templates/admin/form_list.html
@@ -230,7 +230,7 @@
         event: '',
         role: '',
         level: '',
-        participantCount: 'N/A'
+        participantCount: '{{ _("N/A/") }}'
       }
     },
     computed: {
@@ -280,7 +280,7 @@
             if (result.participants !== null) {
               instance.participantCount = result.participants;
             } else {
-              instance.participantCount = 'N/A';
+              instance.participantCount = '{{ _("N/A") }}';
             }
           })
       }

--- a/apollo/templates/admin/form_list.html
+++ b/apollo/templates/admin/form_list.html
@@ -230,7 +230,7 @@
         event: '',
         role: '',
         level: '',
-        participantCount: '{{ _("N/A/") }}'
+        participantCount: '{{ _("N/A") }}'
       }
     },
     computed: {


### PR DESCRIPTION
![Screenshot 2023-08-08 at 00-25-05 Forms - Apollo](https://github.com/nditech/apollo/assets/1408662/c3320f7d-ae06-408c-8d95-2a8118b9836f)
This pull request adds the number of participants found to the checklist creation popup, as can be seen above. Changing the event, location type and role dropdowns changes the number retrieved.

![Screenshot 2023-08-08 at 00-35-02 Forms - Apollo](https://github.com/nditech/apollo/assets/1408662/6b2a2d0b-7bcb-45d6-9d9e-6a7feacbf0c9)

By default - and in the event of an error - the count changes as can be seen above.