### PR TITLE
feat: make questions that failed QA always visible

### DIFF
--- a/apollo/frontend/templates/frontend/submission_edit.html
+++ b/apollo/frontend/templates/frontend/submission_edit.html
@@ -293,13 +293,13 @@
       {# check for data validation or quality assurance errors #}
       {%- for field in group.fields %}
       {%- if submission_form[field.tag].errors %}{% set ns.has_form_error = true %}{% endif %}
-      {%- if field.tag in failed_check_tags and submission.form.quality_checks_enabled and perms.edit_submission_verification_status.can() -%}{% set ns.has_qa_error = true %}{% endif %}
+      {%- if field.tag in failed_check_tags and submission.form.quality_checks_enabled -%}{% set ns.has_qa_error = true %}{% endif %}
       {%- endfor %}
       <div id="grp{{ loop.index }}" class="card-body {% if submission.completion(group.name) == 'Complete' and not ns.has_form_error and not ns.has_qa_error %} collapse{% else %} show{% endif %} py-0 px-0">
         <table class="table table-borderless mb-0 table-responsive">
           <tbody>
           {% for field in group.fields %}
-            <tr {%- if field.tag in failed_check_tags and submission.form.quality_checks_enabled and field.tag not in submission.verified_fields and perms.edit_submission_verification_status.can() %} class="bg-warning"{% endif %}>
+            <tr {%- if field.tag in failed_check_tags and submission.form.quality_checks_enabled and field.tag not in submission.verified_fields %} class="bg-warning"{% endif %}>
               <td class="align-middle" style="width: 0.1%; white-space: nowrap;"><strong>{{ field.tag }}</strong></td>
               <td class="align-middle obs-on">
                 <div class="d-flex align-items-center justify-content-between">


### PR DESCRIPTION
this commit removes the requirement for the edit submission verification status permission
to **view** which questions failed QA, as requested by the election team for the CIV instance

this means that no specific permission is required to see what questions failed QA when editing
a checklist, but verification is still limited.