### PR TITLE
feat: preserve field creation order for exports

### DIFF
--- a/apollo/formsframework/models.py
+++ b/apollo/formsframework/models.py
@@ -138,6 +138,13 @@ class Form(Resource):
             self._populate_field_cache()
 
         return sorted(self._field_cache.keys())
+    
+    @property
+    def unsorted_tags(self):
+        if not hasattr(self, '_field_cache'):
+            self._populate_field_cache()
+
+        return list(self._field_cache.keys())
 
     @property
     def qa_tags(self):

--- a/apollo/submissions/services.py
+++ b/apollo/submissions/services.py
@@ -57,7 +57,7 @@ class SubmissionService(Service):
         ).all()
         samples = Sample.query.filter_by(
             participant_set_id=event.participant_set_id).all()
-        tags = form.tags
+        tags = form.unsorted_tags
 
         extra_field_headers = [fi.label for fi in extra_fields]
 


### PR DESCRIPTION
requested by @anissamaali: in checklist exports, the question order should follow the creation order in the form builder, not alphabetical