### PR TITLE
fix: unset participant language from the UI

### DIFF
--- a/apollo/participants/views_participants.py
+++ b/apollo/participants/views_participants.py
@@ -465,6 +465,8 @@ def participant_edit(id, participant_set_id=0, view=None):
 
             if form.locale.data:
                 participant.locale = form.locale.data
+            else:
+                participant.locale = None
 
             phone_number = phone_number_cleaner.sub('', form.phone.data)
             # do we have a phone number like this in the database?


### PR DESCRIPTION
this was fixed before (39165ea4bc72d69ec99f6ca4bdab39f0f63b5252). perhaps a merge clobbered it?

fixes: nditech/apollo-issues#227