### PR TITLE
fix: replace all usage of _joined_entities()

### DIFF
--- a/apollo/dal/test_utils.py
+++ b/apollo/dal/test_utils.py
@@ -1,0 +1,56 @@
+import pytest
+import sqlalchemy as sa
+import sqlalchemy.orm as so
+from sqlalchemy.ext.declarative import declarative_base
+
+from apollo.dal.utils import has_model
+
+BaseModel = declarative_base()
+
+
+class User(BaseModel):
+    __tablename__ = 'users'
+    
+    id = sa.Column(sa.Integer, primary_key=True)
+    name = sa.Column(sa.String)
+
+
+class Address(BaseModel):
+    __tablename__ = 'addresses'
+    
+    id = sa.Column(sa.Integer, primary_key=True)
+    user_id = sa.Column(sa.Integer, sa.ForeignKey('users.id'))
+    email = sa.Column(sa.String)
+    
+    user = so.relationship('User', backref='addresses')
+
+
+@pytest.fixture(scope='module')
+def engine():
+    engine = sa.create_engine('sqlite:///:memory:')
+    BaseModel.metadata.create_all(engine)
+    return engine
+
+
+@pytest.fixture(scope='function')
+def session(engine):
+    Session = so.sessionmaker(bind=engine)
+    session = Session()
+    yield session
+    session.close()
+
+
+def test_has_model_with_single_model(session):
+    query = session.query(User)
+    assert has_model(query, User)
+    assert not has_model(query, Address)
+
+def test_has_model_with_joined_model(session):
+    query = session.query(User).join(User.addresses)
+    assert has_model(query, User)
+    assert has_model(query, Address)
+
+def test_has_model_with_no_model(session):
+    query = session.query(User).filter(User.id == 1)
+    assert has_model(query, User)
+    assert not has_model(query, Address)

--- a/apollo/dal/utils.py
+++ b/apollo/dal/utils.py
@@ -1,0 +1,29 @@
+from contextlib import suppress
+
+from sqlalchemy.orm import Query
+from sqlalchemy.sql import visitors
+
+from apollo.dal.models import BaseModel
+
+
+def has_model(query: Query, model: BaseModel) -> bool:
+    # thanks to the very helpful poster who posted on SO:
+    # https://stackoverflow.com/a/66855484
+    for visitor in visitors.iterate(query.statement):
+        if visitor.__visit_name__ == "binary":
+            for vis in visitors.iterate(visitor):
+                with suppress(AttributeError):
+                    if model.__table__.fullname == vis.table.fullname:
+                        return True
+
+        if visitor.__visit_name__ == "table":
+            with suppress(TypeError):
+                if model == visitor.entity_namespace:
+                    return True
+
+        if visitor.__visit_name__ == "column":
+            with suppress(AttributeError):
+                if model.__table__.fullname == visitor.table.fullname:
+                    return True
+
+    return False

--- a/apollo/dal/utils.py
+++ b/apollo/dal/utils.py
@@ -7,6 +7,11 @@ from apollo.dal.models import BaseModel
 
 
 def has_model(query: Query, model: BaseModel) -> bool:
+    '''
+    This function goes over the select statement for a query
+    and checks to see if the model class `model` is joined
+    in the query.
+    '''
     # thanks to the very helpful poster who posted on SO:
     # https://stackoverflow.com/a/66855484
     for visitor in visitors.iterate(query.statement):

--- a/apollo/submissions/filters.py
+++ b/apollo/submissions/filters.py
@@ -15,6 +15,7 @@ from wtforms_alchemy.fields import QuerySelectField
 
 from apollo import models
 from apollo.core import BooleanFilter, CharFilter, ChoiceFilter, FilterSet
+from apollo.dal import utils
 from apollo.helpers import _make_choices
 from apollo.settings import TIMEZONE
 from apollo.submissions.models import FLAG_CHOICES
@@ -63,9 +64,7 @@ def make_submission_sample_filter(
             super().__init__(*args, **kwargs)
 
         def filter_by_locations(self, query, value):
-            joined_classes = [
-                mapper.class_ for mapper in query._join_entities]
-            if models.Location in joined_classes:
+            if utils.has_model(query, models.Location):
                 query1 = query
             else:
                 query1 = query.join(models.Submission.location)

--- a/apollo/submissions/views_submissions.py
+++ b/apollo/submissions/views_submissions.py
@@ -27,6 +27,7 @@ from werkzeug.datastructures import MultiDict
 
 from apollo import models, services, utils
 from apollo.core import db, docs
+from apollo.dal import utils
 from apollo.frontend import route, permissions
 from apollo.frontend.helpers import (
     DictDiffer, displayable_location_types, get_event,
@@ -215,8 +216,7 @@ def submission_list(form_id):
                 models.Submission.form == form,
                 models.Submission.event == event,
             )
-            joined_classes = [mapper.class_ for mapper in query._join_entities]
-            if models.Location in joined_classes:
+            if utils.has_model(queryset, models.Location):
                 queryset = queryset.order_by(models.Location.code)
             else:
                 queryset = queryset.join(
@@ -231,8 +231,7 @@ def submission_list(form_id):
                 models.Submission.form == form,
                 models.Submission.event == event,
             )
-            joined_classes = [mapper.class_ for mapper in query._join_entities]
-            if models.Location not in joined_classes:
+            if not utils.has_model(queryset, models.Location):
                 queryset = queryset.join(models.Submission.location)
             queryset = queryset.join(
                 models.Participant,


### PR DESCRIPTION
SQLAlchemy 1.4 removed an internal query method (`_joined_entities()`) that was used to check if a query was already joined to a model. This pull request replaces the usages of that method.

Prior to this, filtering by samples in some cases would error out, and it also affected observer submission exports.