### PR TITLE
fix: don't retrieve hidden forms

### DIFF
--- a/apollo/formsframework/api/views.py
+++ b/apollo/formsframework/api/views.py
@@ -40,7 +40,9 @@ class FormListResource(BaseListResource):
         else:
             deployment_id = None
 
-        query = Form.query.filter_by(deployment_id=deployment_id)
+        query = Form.query.filter_by(
+            deployment_id=deployment_id, is_hidden=False
+        )
 
         form_type = kwargs.get('form_type')
         if form_type:

--- a/apollo/participants/api/views.py
+++ b/apollo/participants/api/views.py
@@ -218,7 +218,8 @@ def _get_form_data(participant):
     # get incident forms
     incident_forms = Form.query.join(Form.events).filter(
         Event.participant_set_id == participant.participant_set_id,
-        Form.form_type == 'INCIDENT'
+        Form.form_type == 'INCIDENT',
+        Form.is_hidden == False,
     ).with_entities(Form).order_by(Form.name, Form.id)
 
     # get participant submissions
@@ -229,8 +230,12 @@ def _get_form_data(participant):
     # get checklist and survey forms based on the available submissions
     non_incident_forms = participant_submissions.with_entities(
         Form).distinct(Form.id)
-    checklist_forms = non_incident_forms.filter(Form.form_type == 'CHECKLIST')
-    survey_forms = non_incident_forms.filter(Form.form_type == 'SURVEY')
+    checklist_forms = non_incident_forms.filter(
+        Form.form_type == 'CHECKLIST', Form.is_hidden == False
+    )
+    survey_forms = non_incident_forms.filter(
+        Form.form_type == 'SURVEY', Form.is_hidden == False
+    )
 
     # get form serial numbers
     form_ids_with_serials = participant_submissions.filter(


### PR DESCRIPTION
this PR makes the two APIs for forms respect the new `is_hidden` attribute.