### PR TITLE
chore: update cache version

### DIFF
--- a/apollo/pwa/static/js/serviceworker.js
+++ b/apollo/pwa/static/js/serviceworker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'apollo-cache-static-v9';
+const CACHE_NAME = 'apollo-cache-static-v10';
 
 const CACHED_URLS = [
   '/pwa/',


### PR DESCRIPTION
update the cache version for the PWA, which should cause the service worker to reload the assets