### PR TITLE
auto populate the location from the participant

### DIFF
--- a/apollo/frontend/templates/frontend/incident_add.html
+++ b/apollo/frontend/templates/frontend/incident_add.html
@@ -108,7 +108,7 @@
       var fileInput = changeEventObj.target;
       var container = fileInput.parentElement;
       var selectButton = container.children[1];
-      
+
       if (fileInput.files.length) {
         selectButton.classList.remove('btn-secondary');
         selectButton.classList.add('btn-primary');
@@ -140,6 +140,12 @@
 
     $('.select2-locations').select2(addIncidentLocationOptions);
     $('.select2-participants').select2(addIncidentParticipantOptions);
+    $('.select2-participants').on('select2:select', function (e) {
+      if (e.params.data["location.id"] !== undefined) {
+        var opt = new Option(e.params.data["location.name"] + " · " + e.params.data["location.location_type.name"], e.params.data["location.id"], true, true);
+        $('.select2-locations').append(opt).trigger('change');
+      }
+    });
 
     $(document).on('change', '.tracked', function(e){
       window.onbeforeunload = function () { return true; };

--- a/apollo/participants/api/schema.py
+++ b/apollo/participants/api/schema.py
@@ -12,7 +12,19 @@ class ParticipantSchema(BaseModelSchema):
         """ParticipantSchema Meta."""
 
         model = Participant
-        fields = ("id", "name", "full_name", "first_name", "other_names", "last_name", "participant_id", "role")
+        fields = (
+            "id",
+            "name",
+            "full_name",
+            "first_name",
+            "other_names",
+            "last_name",
+            "participant_id",
+            "role",
+            "location.id",
+            "location.name",
+            "location.location_type.name",
+        )
 
     def get_role(self, obj):
         return obj.role.name


### PR DESCRIPTION
When creating critical incident reports, users have to not only select the participant but also their location. This requires that the user knows the location that the participant is in. This PR auto-populates the location of the participant and allows the user to change it if the report is being made from a different location.